### PR TITLE
Addresses Typos and Documentation issues

### DIFF
--- a/src/PEAKLib.Core/CustomPrefabPool.cs
+++ b/src/PEAKLib.Core/CustomPrefabPool.cs
@@ -33,6 +33,20 @@ internal class CustomPrefabPool : IPunPrefabPool
 
     internal CustomPrefabPool() { }
 
+    /// <summary>
+    /// Registers a prefab with the prefab pool for later use
+    /// </summary>
+    /// <param name="prefabId">A string ID for the prefab</param>
+    /// <param name="prefab">The GameObject used for instantiating</param>
+    /// <returns>
+    /// Returns <b>TRUE</b> if the prefab is successfully registered.
+    /// Returns <b>FALSE</b> if the prefab is already registered or a vanilla prefab exists with the same ID
+    /// </returns>
+    /// <remarks>
+    /// This method utilizes <see cref="CorePlugin.Log"/>. Any registrations must take place
+    /// <b>after</b> the standard <em>BaseUnityPlugin.Awake</em> or PeakLib must be added as a BepInExDependency
+    /// to avoid issues with potential null references 
+    /// </remarks>
     public bool TryRegisterPrefab(string prefabId, GameObject prefab)
     {
         prefabId = ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(prefabId);

--- a/src/PEAKLib.Core/CustomPrefabPool.cs
+++ b/src/PEAKLib.Core/CustomPrefabPool.cs
@@ -35,7 +35,7 @@ internal class CustomPrefabPool : IPunPrefabPool
 
     public bool TryRegisterPrefab(string prefabId, GameObject prefab)
     {
-        prefabId = ThrowHelper.ThrowIfArgumentNullOrWriteSpace(prefabId);
+        prefabId = ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(prefabId);
 
         if (HasPrefab(prefabId))
         {
@@ -69,7 +69,7 @@ internal class CustomPrefabPool : IPunPrefabPool
 
     public bool TryGetPrefab(string prefabId, [NotNullWhen(true)] out GameObject? prefab)
     {
-        prefabId = ThrowHelper.ThrowIfArgumentNullOrWriteSpace(prefabId);
+        prefabId = ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(prefabId);
 
         if (idToGameObject.TryGetValue(prefabId, out prefab))
         {
@@ -82,7 +82,7 @@ internal class CustomPrefabPool : IPunPrefabPool
 
     public GameObject? Instantiate(string prefabId, Vector3 position, Quaternion rotation)
     {
-        prefabId = ThrowHelper.ThrowIfArgumentNullOrWriteSpace(prefabId);
+        prefabId = ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(prefabId);
 
         GameObject result;
 

--- a/src/PEAKLib.Core/CustomPrefabPool.cs
+++ b/src/PEAKLib.Core/CustomPrefabPool.cs
@@ -47,6 +47,7 @@ internal class CustomPrefabPool : IPunPrefabPool
     /// <b>after</b> the standard <em>BaseUnityPlugin.Awake</em> or PeakLib must be added as a BepInExDependency
     /// to avoid issues with potential null references 
     /// </remarks>
+    /// <exception cref="System.ArgumentException">Thrown if the prefabID is null</exception>
     public bool TryRegisterPrefab(string prefabId, GameObject prefab)
     {
         prefabId = ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(prefabId);

--- a/src/PEAKLib.Core/NetworkPrefabManager.cs
+++ b/src/PEAKLib.Core/NetworkPrefabManager.cs
@@ -138,7 +138,7 @@ public static class NetworkPrefabManager
         object[]? data = null
     )
     {
-        ThrowHelper.ThrowIfArgumentNullOrWriteSpace(prefabId);
+        ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(prefabId);
 
         if (!HasNetworkPrefab(prefabId))
         {

--- a/src/PEAKLib.Core/ThrowHelper.cs
+++ b/src/PEAKLib.Core/ThrowHelper.cs
@@ -17,7 +17,7 @@ public static class ThrowHelper
     /// <returns>A non-null string <paramref name="field"/>.</returns>
     /// <exception cref="NullReferenceException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string ThrowIfFieldNullOrWriteSpace(
+    public static string ThrowIfFieldNullOrWhiteSpace(
         [NotNull] string? field,
         [CallerArgumentExpression(nameof(field))] string name = ""
     )
@@ -56,7 +56,7 @@ public static class ThrowHelper
     /// <returns>A non-null string <paramref name="argument"/>.</returns>
     /// <exception cref="NullReferenceException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string ThrowIfArgumentNullOrWriteSpace(
+    public static string ThrowIfArgumentNullOrWhiteSpace(
         [NotNull] string? argument,
         [CallerArgumentExpression(nameof(argument))] string name = ""
     )

--- a/src/PEAKLib.Core/UnityEditor/UnityModDefinition.cs
+++ b/src/PEAKLib.Core/UnityEditor/UnityModDefinition.cs
@@ -30,9 +30,9 @@ public class UnityModDefinition : ScriptableObject, IModDefinitionResolvable
     /// <inheritdoc/>
     public ModDefinition Resolve()
     {
-        ThrowHelper.ThrowIfFieldNullOrWriteSpace(modId);
-        ThrowHelper.ThrowIfFieldNullOrWriteSpace(modName);
-        ThrowHelper.ThrowIfFieldNullOrWriteSpace(modVersion);
+        ThrowHelper.ThrowIfFieldNullOrWhiteSpace(modId);
+        ThrowHelper.ThrowIfFieldNullOrWhiteSpace(modName);
+        ThrowHelper.ThrowIfFieldNullOrWhiteSpace(modVersion);
 
         Version version;
         try


### PR DESCRIPTION
Summary:
 - Changes ThrowHelper methods from names containing `WriteSpace` to `WhiteSpace` as that seems to be intended
 - Adds an XMLDoc summary to `CustomPrefabPool.TryRegisterPrefab` that explains the lifecycle and expectations of when to register with the pool to potential users. Describes return values and exceptions thrown.