### PR TITLE
Logs and Resolves collision on item ID

### DIFF
--- a/src/PEAKLib.Items/Hooks/ItemDatabaseHooks.cs
+++ b/src/PEAKLib.Items/Hooks/ItemDatabaseHooks.cs
@@ -50,21 +50,20 @@ static class ItemDatabaseHooks
             var hash = MD5.Create()
                 .ComputeHash(Encoding.UTF8.GetBytes(registeredItem.Mod.Id + item.name));
 
-            ushort id = BitConverter.ToUInt16(hash, 0);
-            item.itemID = id;
+            item.itemID = BitConverter.ToUInt16(hash, 0);
 
-            if(self.itemLookup.ContainsKey(id))
+            if(self.itemLookup.ContainsKey(item.itemID))
             {
                 // Log Collision
                 Log.LogError(
-                    $"ItemDatabaseHooks: Prefix_OnLoaded: Collision on hash itemID \"{id}\" for {registeredItem.Mod.Id}.{item.name}"
+                    $"ItemDatabaseHooks: Prefix_OnLoaded: Collision on hash itemID \"{item.itemID}\" for {registeredItem.Mod.Id}.{item.name}"
                 );
 
-                if (!Resolve_Collision(self,ref id))
+                if (!Resolve_Collision(self,ref item.itemID))
                 {
                     // Log Unresolvable Collision
                     Log.LogError(
-                        $"ItemDatabaseHooks: Prefix_OnLoaded: Could not resolve collision on itemID \"{id}\" for {registeredItem.Mod.Id}.{item.name}"
+                        $"ItemDatabaseHooks: Prefix_OnLoaded: Could not resolve collision on itemID \"{item.itemID}\" for {registeredItem.Mod.Id}.{item.name}"
                     );
                 }
             }
@@ -91,7 +90,7 @@ static class ItemDatabaseHooks
 
             // Add item to database
             self.Objects.Add(item);
-            self.itemLookup.Add(id, item);
+            self.itemLookup.Add(item.itemID, item);
         }
     }
 }

--- a/src/PEAKLib.Items/Hooks/ItemDatabaseHooks.cs
+++ b/src/PEAKLib.Items/Hooks/ItemDatabaseHooks.cs
@@ -55,13 +55,18 @@ static class ItemDatabaseHooks
             if(self.itemLookup.ContainsKey(item.itemID))
             {
                 // Log Collision
-                Log.LogError(
+                Log.LogInfo(
                     $"ItemDatabaseHooks: Prefix_OnLoaded: Collision on hash itemID \"{item.itemID}\" for {registeredItem.Mod.Id}.{item.name}"
                 );
 
-                if (!Resolve_Collision(self,ref item.itemID))
+                if (Resolve_Collision(self, ref item.itemID))
                 {
-                    // Log Unresolvable Collision
+                    Log.LogInfo(
+                        $"ItemDatabaseHooks: Prefix_OnLoaded: itemID changed to \"{item.itemID}\" for {registeredItem.Mod.Id}.{item.name}"
+                    );
+                }
+                else
+                {
                     Log.LogError(
                         $"ItemDatabaseHooks: Prefix_OnLoaded: Could not resolve collision on itemID \"{item.itemID}\" for {registeredItem.Mod.Id}.{item.name}"
                     );


### PR DESCRIPTION
It is possible, however unlikely, for two items to hash to the same `ushort` item ID based on the MD5 hash of `registeredItem.Mod.Id` + `item.name`. Currently a second item would quietly replace the old item, while the old item would still exist in the `Objects` collection.

With this patch, in the event of a collision:
- The event is logged 
- Attempts to resolve the collision using linear scan (statistically like to resolve in very few iterations)
- Logs the new item ID resulting from successful resolution
- Logs the extreme failure case that there is no other ID available (65536 items already exist) as an error
- Returns to the original behavior in this extreme failure case (the new item replaces original item)