### PR TITLE
Better Bundle Loader

### DIFF
--- a/src/PEAKLib.Core/BundleLoader.cs
+++ b/src/PEAKLib.Core/BundleLoader.cs
@@ -45,6 +45,8 @@ public static class BundleLoader
 
     private static void AddOperation(LoadOperation operation)
     {
+        CorePlugin.Log.LogInfo($"Loading bundle at '{operation.Path}'...");
+
         if (bundleLoadingWindowClosed)
         {
             CorePlugin.Log.LogWarning(
@@ -120,8 +122,7 @@ public static class BundleLoader
 
         foreach (string path in files)
         {
-            CorePlugin.Log.LogInfo($"Loading bundle at '{path}'...");
-            _operations.Add(new LoadOperation(path, onLoaded, loadContents, modDefinition));
+            AddOperation(new LoadOperation(path, onLoaded, loadContents, modDefinition));
         }
     }
 
@@ -143,8 +144,7 @@ public static class BundleLoader
         ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(path);
         ThrowHelper.ThrowIfArgumentNull(onLoaded);
 
-        CorePlugin.Log.LogInfo($"Loading bundle at '{path}'...");
-        _operations.Add(new LoadOperation(path, onLoaded, loadContents: false, mod));
+        AddOperation(new LoadOperation(path, onLoaded, loadContents: false, mod));
     }
 
     /// <summary>
@@ -168,8 +168,7 @@ public static class BundleLoader
     {
         ThrowHelper.ThrowIfArgumentNullOrWhiteSpace(path);
 
-        CorePlugin.Log.LogInfo($"Loading bundle at '{path}'...");
-        _operations.Add(new LoadOperation(path, onLoaded, loadContents: true, mod));
+        AddOperation(new LoadOperation(path, onLoaded, loadContents: true, mod));
     }
 
     internal static IEnumerator LoadOperationsDeadlineWait(MonoBehaviour behaviour)

--- a/src/PEAKLib.Core/CHANGELOG.md
+++ b/src/PEAKLib.Core/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2025-08-07
+## [1.1.0] - 2025-07-09
+
+### Added
+
+- New APIs to BundleLoader.
+
+### Changed
+
+- BundleLoader now loads and registers content as soon as possible, which also means it calls the event for all bundles loaded as soon as possible instead of at airport loading screen.
+- BundleLoader now has an UI indication if PEAKLib is taking a while loading asset bundles.
+
+## [1.0.0] - 2025-07-08
 
 ### Added
 

--- a/src/PEAKLib.Core/Extensions/ActionExtensions.cs
+++ b/src/PEAKLib.Core/Extensions/ActionExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+
+namespace PEAKLib.Core.Extensions;
+
+internal static class ActionExtensions
+{
+    public static void SafeInvoke(this Action @delegate)
+    {
+        foreach (var callback in @delegate.GetInvocationList().Cast<Action>())
+        {
+            try
+            {
+                callback();
+            }
+            catch (Exception ex)
+            {
+                CorePlugin.Log.LogError($"Unhandled exception in callback: {ex}");
+            }
+        }
+    }
+
+    public static void SafeInvoke<T1>(this Action<T1> @delegate, T1 t1)
+    {
+        foreach (var callback in @delegate.GetInvocationList().Cast<Action<T1>>())
+        {
+            try
+            {
+                callback(t1);
+            }
+            catch (Exception ex)
+            {
+                CorePlugin.Log.LogError($"Unhandled exception in callback: {ex}");
+            }
+        }
+    }
+}

--- a/src/PEAKLib.Core/Hooks/LoadingScreenHanderHooks.cs
+++ b/src/PEAKLib.Core/Hooks/LoadingScreenHanderHooks.cs
@@ -12,7 +12,7 @@ namespace PEAKLib.Core.Hooks;
 [MonoDetourTargets(typeof(LoadingScreenHandler), GenerateControlFlowVariants = true)]
 static class LoadingScreenHandlerHooks
 {
-    static bool loadedBundles;
+    static bool loadBundlesStepInjected;
 
     static readonly EnumeratorFieldReferenceGetter<string> sceneName = LoadSceneProcess
         .StateMachineTarget()
@@ -32,14 +32,14 @@ static class LoadingScreenHandlerHooks
         if (self.State is not 0)
             return ReturnFlow.None;
 
-        if (loadedBundles is true)
+        if (loadBundlesStepInjected is true)
             return ReturnFlow.None;
 
         if (sceneName(self.Enumerator) is not "Airport")
             return ReturnFlow.None;
 
-        self.Current = BundleLoader.FinishLoadOperationsRoutine(self.This);
-        loadedBundles = true;
+        self.Current = BundleLoader.LoadOperationsDeadlineWait(self.This);
+        loadBundlesStepInjected = true;
         continueEnumeration = true;
         return ReturnFlow.HardReturn;
     }

--- a/src/PEAKLib.Core/PEAKLib.Core.csproj
+++ b/src/PEAKLib.Core/PEAKLib.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>com.github.PEAKModding.PEAKLib.Core</AssemblyName>
     <AssemblyTitle>PEAKLib.Core</AssemblyTitle>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <!-- NuGet metadata -->

--- a/src/PEAKLib.Core/PEAKLib.Core.csproj
+++ b/src/PEAKLib.Core/PEAKLib.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>com.github.PEAKModding.PEAKLib.Core</AssemblyName>
     <AssemblyTitle>PEAKLib.Core</AssemblyTitle>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <!-- NuGet metadata -->

--- a/src/PEAKLib.Core/PeakBundle.cs
+++ b/src/PEAKLib.Core/PeakBundle.cs
@@ -21,6 +21,8 @@ public sealed class PeakBundle
     }
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public bool Contains(string name) => bundle.Contains(name);
+
     public Object LoadAsset(string name) => bundle.LoadAsset(name);
 
     public T LoadAsset<T>(string name)

--- a/src/PEAKLib.Core/Plugin.cs
+++ b/src/PEAKLib.Core/Plugin.cs
@@ -41,7 +41,7 @@ public partial class CorePlugin : BaseUnityPlugin
 
     private void Start()
     {
-        BundleLoader.bundleLoadingWindowClosed = true;
+        BundleLoader.CloseBundleLoadingWindow();
     }
 }
 #endif

--- a/src/PEAKLib.Core/Plugin.cs
+++ b/src/PEAKLib.Core/Plugin.cs
@@ -15,11 +15,18 @@ namespace PEAKLib.Core;
 public partial class CorePlugin : BaseUnityPlugin
 {
     internal static ManualLogSource Log { get; } = BepInEx.Logging.Logger.CreateLogSource(Name);
-    internal static CorePlugin Instance { get; private set; } = null!;
+    internal static CorePlugin Instance =>
+        _instance
+        ?? throw new NullReferenceException(
+            "PEAKLib.Core hasn't been initialized yet! "
+                + "Please depend on it with [BepInDependency(CorePlugin.Id)]"
+        );
+
+    private static CorePlugin? _instance = null;
 
     private void Awake()
     {
-        Instance = this;
+        _instance = this;
         MonoDetourManager.InvokeHookInitializers(typeof(CorePlugin).Assembly);
 
         PlayerHandler.OnCharacterRegistered += (Character character) =>

--- a/src/PEAKLib.Core/Plugin.cs
+++ b/src/PEAKLib.Core/Plugin.cs
@@ -38,5 +38,10 @@ public partial class CorePlugin : BaseUnityPlugin
 
         Log.LogInfo($"Plugin {Name} is loaded!");
     }
+
+    private void Start()
+    {
+        BundleLoader.bundleLoadingWindowClosed = true;
+    }
 }
 #endif

--- a/src/PEAKLib.Core/Plugin.cs
+++ b/src/PEAKLib.Core/Plugin.cs
@@ -15,9 +15,11 @@ namespace PEAKLib.Core;
 public partial class CorePlugin : BaseUnityPlugin
 {
     internal static ManualLogSource Log { get; } = BepInEx.Logging.Logger.CreateLogSource(Name);
+    internal static CorePlugin Instance { get; private set; } = null!;
 
     private void Awake()
     {
+        Instance = this;
         MonoDetourManager.InvokeHookInitializers(typeof(CorePlugin).Assembly);
 
         PlayerHandler.OnCharacterRegistered += (Character character) =>


### PR DESCRIPTION
- PEAKLib loading text appears only after 3 seconds of bundle loading in airport loading screen
  - The text also disappears with one (1) second of delay
  - This is to make PEAKLib feel much more invisible with lighter modpacks, and to prevent quickly flashing loading text
- Bundles are now fully loaded and contents registered as soon as possible, instead of at loading screen 
- A new event per bundle loaded is provided for developers to subscribe to if they need mods to be loaded in the menu for their own purposes