### PR TITLE
temporary fix for "LOC: "

### DIFF
--- a/src/PEAKLib.ModConfig/CHANGELOG.md
+++ b/src/PEAKLib.ModConfig/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-07-11
+
+### Changed
+
+- Fixed "LOC: " text appearing before option names
+
 ## [0.1.2] - 2025-07-08
 
 ### Changed

--- a/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
@@ -68,9 +68,25 @@ internal class ModdedSettingsMenu : MonoBehaviour
                 return;
             }
 
+            if (item is not Setting setting)
+            {
+                ModConfigPlugin.Log.LogError("Invalid IExposedSetting");
+                return;
+            }
+
             SettingsUICell component = Instantiate(MenuWindowHooks.SettingsCellPrefab, Content).GetComponent<SettingsUICell>();
             m_spawnedCells.Add(component);
-            component.Setup(item as Setting);
+            // component.Setup(item as Setting);
+
+            // temporary fix - uncomment component.Setup and remove the region when they set printDebug default to false in LocalizedText.GetText(string id, bool printDebug = true)
+
+            #region temporary fix
+            component.m_text.text = item.GetDisplayName();
+            component.m_canvasGroup = component.GetComponent<CanvasGroup>();
+            component.m_canvasGroup.alpha = 0f;
+
+            Instantiate(setting.GetSettingUICell(), component.m_settingsContentParent).GetComponent<SettingInputUICell>().Setup(setting, GameHandler.Instance.SettingsHandler);
+            #endregion
         }
 
         m_fadeInCoroutine = StartCoroutine(FadeInCells());

--- a/src/PEAKLib.ModConfig/PEAKLib.ModConfig.csproj
+++ b/src/PEAKLib.ModConfig/PEAKLib.ModConfig.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>com.github.PEAKModding.PEAKLib.ModConfig</AssemblyName>
     <AssemblyTitle>PEAKLib.ModConfig</AssemblyTitle>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
just a fix for the "LOC: " text in ModSettings

fix can be removed when Peak team set `printDebug` default to `false` in `LocalizedText.GetText(string id, bool printDebug = true)`
