### PR TITLE
Fix tests not working on certain days

### DIFF
--- a/tests/PEAKLib.Tests/Plugin.cs
+++ b/tests/PEAKLib.Tests/Plugin.cs
@@ -174,8 +174,7 @@ public partial class TestsPlugin : BaseUnityPlugin
         // and game is connected
         Match match = new Regex(@"^Level_(\d+)$").Match(scene.name);
         if (mode == LoadSceneMode.Single && match.Success &&
-            int.TryParse(match.Groups[1].Value, out int level) &&
-            level >= 0 && level <= 13 &&
+            int.TryParse(match.Groups[1].Value, out _) &&
             PhotonNetwork.IsConnected && PhotonNetwork.InRoom)
         {
             Log.LogInfo("Game Start detected, spawning Monolith");


### PR DESCRIPTION
`0 <= level && level <= 13` isn't valid, removing the check