### PR TITLE
UI & ModConfig updates

### DIFF
--- a/src/PEAKLib.ModConfig/Components/ModKeyToName.cs
+++ b/src/PEAKLib.ModConfig/Components/ModKeyToName.cs
@@ -1,15 +1,15 @@
 ﻿using BepInEx.Configuration;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 namespace PEAKLib.ModConfig.Components;
-internal class ModKeyToName(ConfigEntry<KeyCode> key, string name)
+
+internal class ModKeyToName(ConfigEntryBase key, string name)
 {
-    internal ConfigEntry<KeyCode> KeyBind = key;
+    internal ConfigEntryBase KeyBind = key;
     internal string ModName = name;
 
-    internal static List<ModKeyToName> RemoveKey(List<ModKeyToName> keys, ConfigEntry<KeyCode> key)
+    internal static List<ModKeyToName> RemoveKey(List<ModKeyToName> keys, ConfigEntryBase key)
     {
         ModKeyToName item = keys.FirstOrDefault(i => i.KeyBind == key);
         if (item != null)
@@ -18,3 +18,4 @@ internal class ModKeyToName(ConfigEntry<KeyCode> key, string name)
         return keys;
     }
 }
+

--- a/src/PEAKLib.ModConfig/Components/ModKeyToName.cs
+++ b/src/PEAKLib.ModConfig/Components/ModKeyToName.cs
@@ -1,0 +1,20 @@
+﻿using BepInEx.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace PEAKLib.ModConfig.Components;
+internal class ModKeyToName(ConfigEntry<KeyCode> key, string name)
+{
+    internal ConfigEntry<KeyCode> KeyBind = key;
+    internal string ModName = name;
+
+    internal static List<ModKeyToName> RemoveKey(List<ModKeyToName> keys, ConfigEntry<KeyCode> key)
+    {
+        ModKeyToName item = keys.FirstOrDefault(i => i.KeyBind == key);
+        if (item != null)
+            keys.Remove(item);
+
+        return keys;
+    }
+}

--- a/src/PEAKLib.ModConfig/Components/ModSectionNames.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSectionNames.cs
@@ -1,0 +1,54 @@
+﻿using BepInEx.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PEAKLib.ModConfig.Components;
+internal class ModSectionNames
+{
+    internal static List<ModSectionNames> SectionNames { get; set; } = [];
+    internal string ModName { get; set; }
+    internal List<string> Sections { get; set; } = [];
+
+    internal ModSectionNames(string modName)
+    {
+        ModName = modName;
+        SectionNames.Add(this);
+    }
+
+    internal static ModSectionNames SetMod(string modName)
+    {
+        ModSectionNames sectionTracker = SectionNames.FirstOrDefault(x => x.ModName == modName);
+        if (sectionTracker == null!)
+            sectionTracker = new(modName);
+
+        return sectionTracker;
+    }
+
+    internal static bool TryGetModSections(string modName, out List<string> sections)
+    {
+        sections = [];
+        ModSectionNames sectionTracker = SectionNames.FirstOrDefault(x => x.ModName == modName);
+        if (sectionTracker == null)
+            return false;
+
+        sections = sectionTracker.Sections;
+        return sections.Count > 0;
+    }
+
+    internal static bool TryGetFirstSection(string modName, out string section)
+    {
+        section = string.Empty;
+        ModSectionNames sectionTracker = SectionNames.FirstOrDefault(x => x.ModName == modName);
+        if (sectionTracker == null)
+            return false;
+
+        section = sectionTracker.Sections[0];
+        return true;
+    }
+
+    internal void CheckSectionName(string sectionName)
+    {
+        if (!Sections.Contains(sectionName))
+            Sections.Add(sectionName);
+    }
+}

--- a/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
@@ -18,6 +18,8 @@ internal class ModdedSettingsMenu : MonoBehaviour
 
     }
 
+    internal static ModdedSettingsMenu Instance { get; private set; } = null!;
+
     public ModdedSettingsTABS Tabs { get; set; } = null!;
 
     public Transform Content { get; set; } = null!;
@@ -29,6 +31,13 @@ internal class ModdedSettingsMenu : MonoBehaviour
     private Coroutine? m_fadeInCoroutine;
 
     private string search = "";
+
+    internal PeakChildPage MainPage = null!;
+
+    private void Awake()
+    {
+        Instance = this;
+    }
 
     public void SetSearch(string search)
     {

--- a/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
@@ -36,6 +36,7 @@ internal class ModdedSettingsMenu : MonoBehaviour
 
     private void Awake()
     {
+        ModConfigPlugin.Log.LogDebug("ModdedSettingsMenu Awake");
         Instance = this;
     }
 

--- a/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
@@ -97,6 +97,9 @@ internal class ModdedSettingsMenu : MonoBehaviour
             {
                 if (item is IBepInExProperty bep)
                 {
+                    //update assigned value from configbase
+                    bep.RefreshValueFromConfig();
+
                     if (!bep.ConfigBase.Definition.Section.Equals(selectedSection, System.StringComparison.InvariantCultureIgnoreCase))
                         continue; //skip setting that is not in current selected section
                 }

--- a/src/PEAKLib.ModConfig/Components/ModdedControlsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedControlsMenu.cs
@@ -1,0 +1,258 @@
+﻿using BepInEx.Configuration;
+using PEAKLib.UI;
+using PEAKLib.UI.Elements;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+using Zorro.ControllerSupport;
+using Zorro.UI;
+
+namespace PEAKLib.ModConfig.Components;
+
+internal class ModdedControlsMenu : PeakElement
+{
+
+    //original unused stuff
+    public GameObject[] keyboardOnlyObjects = [];
+    public GameObject[] controllerOnlyObjects = [];
+    // ---
+
+    public static ModdedControlsMenu Instance = null!;
+    public List<ModdedRebindKeyCode> controlsMenuButtons = [];
+    public List<GameObject> ModLabels = [];
+
+    private string search = "";
+
+    internal UIPageHandler pageHandler = null!;
+
+    internal bool RebindInProgress = false;
+    internal PeakChildPage MainPage = null!;
+    internal PeakButton RebindNotif = null!;
+    internal ConfigEntry<KeyCode> Selected = null!;
+    internal Transform Content { get; set; } = null!;
+
+    public void Awake()
+    {
+        Instance = this;
+        if (pageHandler == null)
+        {
+            pageHandler = GetComponentInParent<UIPageHandler>();
+        }
+        //Rebinding.LoadRebindingsFromFile();
+    }
+
+    internal void OnResetClicked()
+    {
+        ModConfigPlugin.Log.LogMessage("Resetting all modded settings!");
+        controlsMenuButtons.ForEach(b => 
+        {
+            if (b.ConfigEntry.Value == (KeyCode)b.ConfigEntry.DefaultValue)
+                return;
+
+            b.ConfigEntry.Value = (KeyCode)b.ConfigEntry.DefaultValue;
+            // triggering the animator to make it look like all the reset buttons were pressed
+            b.reset.GetComponent<Button>().animator.SetBool("Pressed", true);
+            b.reset.GetComponent<Button>().animator.SetBool("Disabled", true); 
+        });
+        ShowControls();
+    }
+
+    public void OnDeviceChange(InputScheme scheme)
+    {
+        switch (scheme)
+        {
+            case InputScheme.KeyboardMouse:
+                {
+                    GameObject[] array = keyboardOnlyObjects;
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i].SetActive(value: true);
+                    }
+
+                    array = controllerOnlyObjects;
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i].SetActive(value: false);
+                    }
+
+                    break;
+                }
+            case InputScheme.Gamepad:
+                {
+                    GameObject[] array = keyboardOnlyObjects;
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i].SetActive(value: false);
+                    }
+
+                    array = controllerOnlyObjects;
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        array[i].SetActive(value: true);
+                    }
+
+                    break;
+                }
+        }
+
+        InitButtonBindingVisuals(scheme);
+        LayoutRebuilder.ForceRebuildLayoutImmediate(base.transform as RectTransform);
+    }
+
+    public void InitButtons()
+    {
+        if (pageHandler == null)
+        {
+            pageHandler = GetComponentInParent<UIPageHandler>();
+        }
+
+        var buttonsToCreate = ModConfigPlugin.ModdedKeybinds;
+        if (controlsMenuButtons.Count > 0)
+        {
+            foreach(var button in controlsMenuButtons)
+                buttonsToCreate.Remove(button.ConfigEntry);
+        }
+
+        var ordered = buttonsToCreate.OrderBy(x => x.Value);
+
+        foreach (var config in ordered)
+            AddControlMenuButton(config.Key, config.Value);
+    }
+
+    private void AddControlMenuButton(ConfigEntry<KeyCode> configEntry, string ModName) 
+    {
+        if (Content == null)
+            return;
+
+        if(ModLabels.FirstOrDefault(x => x.name == ModName) is not GameObject modName)
+        {
+            var modText = MenuAPI.CreateText(ModName, ModName)
+                .SetFontSize(36f)
+                .SetColor(Color.green)
+                .ParentTo(Content);
+            modText.TextMesh.alignment = TMPro.TextAlignmentOptions.Center;
+            
+
+            modName = modText.gameObject;
+            ModLabels.Add(modName);
+        }
+
+        GameObject control = new($"({ModName}) {configEntry.Definition.Key}");
+        var item = control.AddComponent<ModdedRebindKeyCode>();
+        item.Label = modName;
+        item.Setup(configEntry, ModName);
+        control.transform.localPosition = Vector3.zero;
+        control.transform.SetParent(Content);
+        controlsMenuButtons.Add(item);
+    }
+
+    public void InitButtonBindingVisuals(InputScheme scheme)
+    {
+        //disable labels before refresh
+        foreach (var item in ModLabels)
+            item.SetActive(false);
+
+        for (int i = 0; i < controlsMenuButtons.Count; i++)
+        {
+            var isSearching = !string.IsNullOrEmpty(search);
+            if (isSearching)
+            {
+                controlsMenuButtons[i].gameObject.SetActive(controlsMenuButtons[i].inputActionName.Contains(search, StringComparison.InvariantCultureIgnoreCase));
+            }
+            else if(!controlsMenuButtons[i].gameObject.activeSelf)
+                controlsMenuButtons[i].gameObject.SetActive(true);
+
+            controlsMenuButtons[i].UpdateBindingVisuals(controlsMenuButtons, scheme);
+
+            //enable labels for active control items
+            if (controlsMenuButtons[i].gameObject.activeSelf)
+                controlsMenuButtons[i].Label.SetActive(true);
+        }
+
+        //Below prob not needed
+        /*
+        for (int i = 0; i < ModLabels.Count; i++)
+        {
+            if (ModLabels[i].transform.childCount == 0)
+            {
+                ModLabels[i].gameObject.SetActive(false);
+                continue;
+            }
+                
+
+            bool showLabel = false;
+            for (int x = 0; x < ModLabels[i].transform.childCount; i++)
+            {
+                if (ModLabels[i].transform.GetChild(x).gameObject.activeSelf)
+                {
+                    showLabel = true;
+                    break;
+                }    
+            }
+
+            ModLabels[i].gameObject.SetActive(showLabel);
+        }*/
+    }
+
+    public void SetSearch(string search)
+    {
+        this.search = search.ToLower();
+        ShowControls(); // just to update the settings
+    }
+
+    public void ShowControls()
+    {
+        RebindNotif?.gameObject.SetActive(false);
+        InitButtons();
+        OnDeviceChange(InputHandler.GetCurrentUsedInputScheme());
+    }
+
+    public void RebindOperation()
+    {
+        if (Selected == null)
+            return;
+
+        transform.gameObject.SetActive(false);
+        RebindInProgress = true;
+        RebindNotif.Text.TextMesh.text = LocalizedText.GetText("PROMPT_REBIND").Replace("@", Selected.Definition.Key.ToString());
+        RebindNotif.gameObject.SetActive(true);
+
+        GUIManager.instance.StartCoroutine(AwaitControl());
+    }
+
+    public IEnumerator AwaitControl()
+    {
+        var action_pause = InputSystem.actions.FindAction("Pause");
+        while (RebindInProgress)
+        {
+            if(action_pause.WasPressedThisFrame())
+            {
+                ModConfigPlugin.Log.LogDebug("Exiting new bind operation!");
+                RebindNotif.gameObject.SetActive(false);
+                RebindInProgress = false;
+                pageHandler.TransistionToPage(MainPage, new SetActivePageTransistion());
+                ShowControls();
+                yield break;
+            }
+
+            if (Input.anyKeyDown)
+            {
+                ModConfigPlugin.Log.LogDebug("Setting new bind value!");
+                KeyCode[] keys = (KeyCode[])Enum.GetValues(typeof(KeyCode));
+                KeyCode key = keys.FirstOrDefault(x => Input.GetKeyDown(x));
+                Selected.Value = key;
+                RebindInProgress = false;
+                RebindNotif.gameObject.SetActive(false);
+                transform.gameObject.SetActive(true);
+                ShowControls();
+                yield break;
+            }
+
+            yield return null;
+        }
+    }
+}

--- a/src/PEAKLib.ModConfig/Components/ModdedControlsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedControlsMenu.cs
@@ -37,12 +37,13 @@ internal class ModdedControlsMenu : PeakElement
 
     public void Awake()
     {
+        ModConfigPlugin.Log.LogDebug("ModdedControlsMenu Awake");
         Instance = this;
         if (pageHandler == null)
         {
             pageHandler = GetComponentInParent<UIPageHandler>();
         }
-        controlsMenuButtons = [];
+
         InitButtons();
     }
 
@@ -115,13 +116,13 @@ internal class ModdedControlsMenu : PeakElement
         if (controlsMenuButtons.Count > 0)
         {
             foreach(var button in controlsMenuButtons)
-                buttonsToCreate.Remove(button.ConfigEntry);
+                ModKeyToName.RemoveKey(buttonsToCreate, button.ConfigEntry);
         }
 
-        var ordered = buttonsToCreate.OrderBy(x => x.Value);
+        var ordered = buttonsToCreate.OrderBy(x => x.ModName);
 
         foreach (var config in ordered)
-            AddControlMenuButton(config.Key, config.Value);
+            AddControlMenuButton(config.KeyBind, config.ModName);
     }
 
     private void AddControlMenuButton(ConfigEntry<KeyCode> configEntry, string ModName) 
@@ -135,9 +136,8 @@ internal class ModdedControlsMenu : PeakElement
                 .SetFontSize(36f)
                 .SetColor(Color.green)
                 .ParentTo(Content);
-            modText.TextMesh.alignment = TMPro.TextAlignmentOptions.Center;
-            
 
+            modText.TextMesh.alignment = TMPro.TextAlignmentOptions.Center;
             modName = modText.gameObject;
             ModLabels.Add(modName);
         }

--- a/src/PEAKLib.ModConfig/Components/ModdedControlsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedControlsMenu.cs
@@ -42,7 +42,8 @@ internal class ModdedControlsMenu : PeakElement
         {
             pageHandler = GetComponentInParent<UIPageHandler>();
         }
-        //Rebinding.LoadRebindingsFromFile();
+        controlsMenuButtons = [];
+        InitButtons();
     }
 
     internal void OnResetClicked()

--- a/src/PEAKLib.ModConfig/Components/ModdedRebindKey.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedRebindKey.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using static PEAKLib.ModConfig.SettingsHandlerUtility;
 
 namespace PEAKLib.ModConfig.Components;
 internal class ModdedRebindKey : PeakElement
@@ -160,11 +161,6 @@ internal class ModdedRebindKey : PeakElement
 
         if(ConfigKeyString != null)
             ConfigKeyString.Value = GetDefaultValue(ConfigKeyString);
-    }
-
-    public static T GetDefaultValue<T>(ConfigEntry<T> entry)
-    {
-        return (T)entry.DefaultValue;
     }
 
     //Rebind button action

--- a/src/PEAKLib.ModConfig/Components/ModdedRebindKeyCode.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedRebindKeyCode.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx.Configuration;
 using PEAKLib.UI;
 using PEAKLib.UI.Elements;
+using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -23,6 +24,7 @@ internal class ModdedRebindKeyCode : PeakElement
     private PeakText value = null!;
     internal GameObject Label = null!;
 
+    //this shit was a LOT of trial and error to get things looking better in a uniform way
     internal void Setup(ConfigEntry<KeyCode> entry, string ModName)
     {
         ConfigEntry = entry;
@@ -30,7 +32,7 @@ internal class ModdedRebindKeyCode : PeakElement
 
         button = MenuAPI.CreateButton(inputActionName)
             .ParentTo(transform)
-            .SetSize(new(950f, 60f))
+            .SetSize(new(1025f, 60f))
             .OnClick(RebindOperation);
 
         button.Button.targetGraphic.color = new(0.3396f, 0.204f, 0.1362f, 0.7294f); //match original controls page
@@ -41,34 +43,79 @@ internal class ModdedRebindKeyCode : PeakElement
         button.Text.TextMesh.fontSizeMin = 18f;
         button.Text.TextMesh.fontSizeMax = 30f;
 
+        //this game object holds the reset button and the value (the right side of the control setting)
+        GameObject rightParent = new($"{ModName} Value");
+        rightParent.transform.SetParent(transform);
+        rightParent.AddComponent<LayoutElement>();
+        rightParent.GetComponent<RectTransform>().anchoredPosition = new(450f, 0f);
+        
         value = MenuAPI.CreateText(ConfigEntry.Value.ToString())
-            .ParentTo(transform)
-            .SetPosition(new(925f, -24f))
-            .SetFontSize(30f)
+            .ParentTo(rightParent.transform)
+            .SetPosition(new(0f, -20f))
+            .SetFontSize(34f)
             .SetColor(defaultTextColor);
 
+        //Below is the setup necessary for the text to behave in a way that it does 
+        //not overlap the reset button and will instead position itself further left
+        var layout = value.gameObject.AddComponent<HorizontalLayoutGroup>();
+        layout.childAlignment = TextAnchor.MiddleLeft;
+        layout.childControlHeight = false;
+        layout.childControlWidth = false;
+        layout.childForceExpandHeight = false;
+        layout.childForceExpandWidth = true;
+        var layoutelement = value.gameObject.AddComponent<LayoutElement>();
+        layoutelement.preferredWidth = 66f;
+        var content = value.gameObject.AddComponent<ContentSizeFitter>();
+        content.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+        value.TextMesh.horizontalAlignment = HorizontalAlignmentOptions.Right; //IMPORTANT
+        value.TextMesh.textWrappingMode = TextWrappingModes.NoWrap; //IMPORTANT
+
+        //This translates the sprite tag to the corresponding sprite
+        value.gameObject.AddComponent<TMP_SpriteAnimator>();
+
+        //This is our warning icon that shows when a control shares the same binding as another
         warning = GameObject.Instantiate(Templates.BindWarningButton!, transform);
-        warning.transform.localPosition = new(-500f, 0f, 0f);
+        warning.transform.localPosition = new(-535f, 0f, 0f);
         warning.SetActive(false);
 
-        reset = GameObject.Instantiate(Templates.ResetBindButton!, transform);
+        //Reset to default button
+        reset = GameObject.Instantiate(Templates.ResetBindButton!, rightParent.transform);
         reset.GetComponent<Button>().onClick.RemoveAllListeners();
         reset.GetComponent<Button>().onClick.AddListener(ResetThis);
-        reset.transform.localPosition = new(445f, 0f, 0f);
+        
+        //Reset button needs the below so it maintains a consistent size
+        var layoutElement = reset.AddComponent<LayoutElement>();
+        layoutElement.preferredWidth = 32f;
+        layoutElement.preferredHeight = 32f;
+        layoutElement.flexibleHeight = 0f;
+        layoutElement.flexibleWidth = 0f;
+
+        //Below ensures reset button is always at the same position of the setting horizontally
+        var rect = reset.GetComponent<RectTransform>();
+        rect.anchorMin = new(1f, 0.5f);
+        rect.anchorMax = new(1f, 0.5f);
+        rect.pivot = new(1f, 0.5f);
+        rect.anchoredPosition = Vector2.zero;
+        
     }
 
+    //Reset button action, resets the setting to the default value
     private void ResetThis()
     {
         ConfigEntry.Value = (KeyCode)ConfigEntry.DefaultValue;
         ModdedControlsMenu.Instance.InitButtonBindingVisuals(InputHandler.GetCurrentUsedInputScheme());
     }
 
+    //Rebind button action
     internal void RebindOperation()
     {
         ModdedControlsMenu.Instance.Selected = ConfigEntry;
         ModdedControlsMenu.Instance.RebindOperation();
     }
 
+    //This refreshes the look of the setting
+    //Changes color of setting value & description if not default value
+    //Displays warning icon if setting is already bound to another key
     public void UpdateBindingVisuals(List<ModdedRebindKeyCode> allButtons, InputScheme scheme)
     {
         bool hasOverride = ConfigEntry.Value != (KeyCode)ConfigEntry.DefaultValue;
@@ -85,11 +132,11 @@ internal class ModdedRebindKeyCode : PeakElement
             }
         }
 
-        //string display = ConfigEntry.Definition.Key + $": <color=green>{ConfigEntry.Value}</color>";
-
         warning.SetActive(warn);
         button.Text.SetText(ConfigEntry.Definition.Key);
-        value.SetText($"{ConfigEntry.Value}");
+        string key = GetValidKeyValue(ConfigEntry.Value);
+        value.TextMesh.spriteAsset = Templates.KeyboardSpriteSheet; //no controller support currently
+        value.SetText($"{key}");
 
         if (hasOverride)
         {
@@ -100,7 +147,62 @@ internal class ModdedRebindKeyCode : PeakElement
         {
             value.TextMesh.color = defaultTextColor;
             button.Text.TextMesh.color = defaultTextColor;
+        }         
+    }
+
+    //Translation for KeyCode to valid sprite tag
+    private static string GetValidKeyValue(KeyCode key)
+    {
+        string search = key.ToString();
+        List<KeyCode> Numbers = [KeyCode.Alpha0, KeyCode.Alpha1, KeyCode.Alpha2, KeyCode.Alpha3, KeyCode.Alpha4, KeyCode.Alpha5, KeyCode.Alpha6, KeyCode.Alpha7, KeyCode.Alpha8, KeyCode.Alpha9];
+
+        List<KeyCode> MouseKeys = [KeyCode.Mouse0, KeyCode.Mouse1, KeyCode.Mouse2, KeyCode.Mouse3, KeyCode.Mouse4, KeyCode.Mouse5, KeyCode.Mouse6];
+
+        if (MouseKeys.Contains(key))
+        {
+            if (key == KeyCode.Mouse0)
+                return "<sprite=109 tint=1>";
+
+            if (key == KeyCode.Mouse1)
+                return "<sprite=110 tint=1>";
+
+            if (key == KeyCode.Mouse2)
+                return "<sprite=111 tint=1>";
+
+            return key.ToString();
         }
-            
+
+        //does not have a sprite (per darmuh's keyboard)
+        //KeyCode.None, KeyCode.Print, KeyCode.ScrollLock, KeyCode.Pause, KeyCode.Numlock, KeyCode.LeftApple (windows key), KeyCode.RightMeta (cmd key)
+
+        if (Numbers.Contains(key))
+            search = search.ToString().Replace("Alpha", "");
+
+        if (search.ToString().Contains("keypad", StringComparison.InvariantCultureIgnoreCase))
+            search = search.ToString().Replace("Keypad", "numpad");
+
+        if (search.ToString().Contains("control", StringComparison.InvariantCultureIgnoreCase))
+            search = search.ToString().Replace("Control", "Ctrl");
+
+        if (search.ToString().Contains("return", StringComparison.InvariantCultureIgnoreCase))
+            search = search.ToString().Replace("Return", "Enter");
+
+        if (search.ToString().Contains("backquote", StringComparison.InvariantCultureIgnoreCase))
+            search = search.ToLowerInvariant();
+
+        //this fixes most conversions that are not covered above
+        search = Char.ToLower(search.ToString()[0]) + search.ToString()[1..];
+
+        //get the actual sprite tag or return original key string if no matching sprite tag
+        if (InputSpriteData.Instance.inputPathToSpriteTagKeyboard.TryGetValue(search, out string sprite))
+            return sprite;
+        else
+            return key.ToString();
+
+        //base game provides the following sprite tag if an unknown input is provided
+        //"<sprite=124 tint=1>"
+        //it's basically just a key with ?? on it
+        //We could provide this instead of the string, but I think the string works better in our case
+
     }
 }

--- a/src/PEAKLib.ModConfig/Components/ModdedRebindKeyCode.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedRebindKeyCode.cs
@@ -1,0 +1,106 @@
+﻿using BepInEx.Configuration;
+using PEAKLib.UI;
+using PEAKLib.UI.Elements;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Zorro.ControllerSupport;
+
+namespace PEAKLib.ModConfig.Components;
+internal class ModdedRebindKeyCode : PeakElement
+{
+    public string inputActionName = string.Empty;
+    internal GameObject warning = null!;
+    internal GameObject rebind = null!;
+    internal GameObject reset = null!;
+
+    internal Color defaultTextColor = new(0.8745f, 0.8549f, 0.7608f);
+    internal Color overriddenTextColor = new(0.8679f, 0.7459f, 0.3316f);
+
+    internal ConfigEntry<KeyCode> ConfigEntry = null!;
+    private PeakButton button = null!;
+    private PeakText value = null!;
+    internal GameObject Label = null!;
+
+    internal void Setup(ConfigEntry<KeyCode> entry, string ModName)
+    {
+        ConfigEntry = entry;
+        inputActionName = $"({ModName}) {entry.Definition.Key}";
+
+        button = MenuAPI.CreateButton(inputActionName)
+            .ParentTo(transform)
+            .SetSize(new(950f, 60f))
+            .OnClick(RebindOperation);
+
+        button.Button.targetGraphic.color = new(0.3396f, 0.204f, 0.1362f, 0.7294f); //match original controls page
+        button.Text.TextMesh.alignment = TextAlignmentOptions.TopLeft;
+        button.Text.TextMesh.margin = new(15f, 5f, 0, 0);
+        button.Text.TextMesh.color = defaultTextColor;
+        button.Text.TextMesh.enableAutoSizing = true;
+        button.Text.TextMesh.fontSizeMin = 18f;
+        button.Text.TextMesh.fontSizeMax = 30f;
+
+        value = MenuAPI.CreateText(ConfigEntry.Value.ToString())
+            .ParentTo(transform)
+            .SetPosition(new(925f, -24f))
+            .SetFontSize(30f)
+            .SetColor(defaultTextColor);
+
+        warning = GameObject.Instantiate(Templates.BindWarningButton!, transform);
+        warning.transform.localPosition = new(-500f, 0f, 0f);
+        warning.SetActive(false);
+
+        reset = GameObject.Instantiate(Templates.ResetBindButton!, transform);
+        reset.GetComponent<Button>().onClick.RemoveAllListeners();
+        reset.GetComponent<Button>().onClick.AddListener(ResetThis);
+        reset.transform.localPosition = new(445f, 0f, 0f);
+    }
+
+    private void ResetThis()
+    {
+        ConfigEntry.Value = (KeyCode)ConfigEntry.DefaultValue;
+        ModdedControlsMenu.Instance.InitButtonBindingVisuals(InputHandler.GetCurrentUsedInputScheme());
+    }
+
+    internal void RebindOperation()
+    {
+        ModdedControlsMenu.Instance.Selected = ConfigEntry;
+        ModdedControlsMenu.Instance.RebindOperation();
+    }
+
+    public void UpdateBindingVisuals(List<ModdedRebindKeyCode> allButtons, InputScheme scheme)
+    {
+        bool hasOverride = ConfigEntry.Value != (KeyCode)ConfigEntry.DefaultValue;
+        bool warn = false;
+        allButtons.RemoveAll(a => a == null!);
+        foreach (ModdedRebindKeyCode pauseMenuRebindButton in allButtons)
+        {
+            if (pauseMenuRebindButton == this)
+                continue;
+
+            if (pauseMenuRebindButton.ConfigEntry.Value == ConfigEntry.Value && pauseMenuRebindButton.ConfigEntry.Value != KeyCode.None)
+            {
+                warn = true;
+            }
+        }
+
+        //string display = ConfigEntry.Definition.Key + $": <color=green>{ConfigEntry.Value}</color>";
+
+        warning.SetActive(warn);
+        button.Text.SetText(ConfigEntry.Definition.Key);
+        value.SetText($"{ConfigEntry.Value}");
+
+        if (hasOverride)
+        {
+            value.TextMesh.color = overriddenTextColor;
+            button.Text.TextMesh.color = overriddenTextColor;
+        }
+        else
+        {
+            value.TextMesh.color = defaultTextColor;
+            button.Text.TextMesh.color = defaultTextColor;
+        }
+            
+    }
+}

--- a/src/PEAKLib.ModConfig/Components/ModdedSettingsSectionTABS.cs
+++ b/src/PEAKLib.ModConfig/Components/ModdedSettingsSectionTABS.cs
@@ -3,13 +3,15 @@ using Zorro.UI;
 
 namespace PEAKLib.ModConfig.Components;
 
-internal class ModdedSettingsTABS : TABS<ModdedTABSButton>
+internal class ModdedSettingsSectionTABS : TABS<ModdedTABSButton>
 {
     public ModdedSettingsMenu? SettingsMenu;
 
     public override void OnSelected(ModdedTABSButton button)
     {
         ThrowHelper.ThrowIfFieldNull(SettingsMenu);
-        SettingsMenu.UpdateSectionTabs(button.category);
+
+        SettingsMenu.SetSection(button.category);
+        
     }
 }

--- a/src/PEAKLib.ModConfig/IBepInExProperty.cs
+++ b/src/PEAKLib.ModConfig/IBepInExProperty.cs
@@ -5,6 +5,8 @@ namespace PEAKLib.ModConfig;
 internal interface IBepInExProperty
 {
     //so we can refresh values from config and add functional section tabs
-    internal ConfigEntryBase ConfigBase { get; } 
+    internal ConfigEntryBase ConfigBase { get; }
+
+    internal void RefreshValueFromConfig();
 }
 

--- a/src/PEAKLib.ModConfig/IBepInExProperty.cs
+++ b/src/PEAKLib.ModConfig/IBepInExProperty.cs
@@ -1,7 +1,10 @@
-﻿namespace PEAKLib.ModConfig;
+﻿using BepInEx.Configuration;
+
+namespace PEAKLib.ModConfig;
 
 internal interface IBepInExProperty
 {
-
+    //so we can refresh values from config and add functional section tabs
+    internal ConfigEntryBase ConfigBase { get; } 
 }
 

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -212,7 +212,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
 
             var modSettingsButton = MenuAPI.CreatePauseMenuButton("MOD SETTINGS")
                 .SetLocalizationIndex(modSettingsLocalization)
-                .SetColor(new Color(0.15f, 0.75f, 0.85f))
+                .SetColor(new Color(0.185f, 0.394f, 0.6226f)) //same blue as main menu settings button
                 .ParentTo(parent)
                 .OnClick(() =>
                 {
@@ -340,7 +340,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
 
             var modControlsButton = MenuAPI.CreatePauseMenuButton("MOD CONTROLS")
                 .SetLocalizationIndex(modControlsLocalization)
-                .SetColor(new Color(0.15f, 0.75f, 0.85f))
+                .SetColor(new Color(0.185f, 0.394f, 0.6226f)) //same blue as main menu settings button
                 .ParentTo(parent)
                 .OnClick(() =>
                 {

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -52,11 +52,14 @@ public partial class ModConfigPlugin : BaseUnityPlugin
         instance = this;
         MonoDetourManager.InvokeHookInitializers(typeof(ModConfigPlugin).Assembly);
         Log.LogInfo($"Plugin {Name} is loaded!");
+
     }
 
     private void Start()
     {
         LoadModSettings();
+
+        MenuAPI.AddEnumSetting<Language>("Language Setting", Language.English, Language.English, SettingsCategory.General);
 
         void builderDelegate(Transform parent)
         {

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -59,8 +59,6 @@ public partial class ModConfigPlugin : BaseUnityPlugin
     {
         LoadModSettings();
 
-        MenuAPI.AddEnumSetting<Language>("Language Setting", Language.English, Language.English, SettingsCategory.General);
-
         void builderDelegate(Transform parent)
         {
             Log.LogDebug("builderDelegate");

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -30,8 +30,8 @@ namespace PEAKLib.ModConfig;
 public partial class ModConfigPlugin : BaseUnityPlugin
 {
     internal static ManualLogSource Log { get; } = BepInEx.Logging.Logger.CreateLogSource(Name);
-    private static List<ConfigEntryBase> EntriesProcessed = [];
-    internal static Dictionary<ConfigEntry<KeyCode>, string> ModdedKeybinds = [];
+    private static List<ConfigEntryBase> EntriesProcessed { get; set; } = [];
+    internal static List<ModKeyToName> ModdedKeybinds { get; set; } = [];
     internal static ModConfigPlugin instance = null!;
 
     private void Awake()
@@ -344,6 +344,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
         if (modSettingsLoaded) return;
 
         EntriesProcessed = [];
+        ModdedKeybinds = [];
         modSettingsLoaded = true;
 
         ProcessModEntries();
@@ -407,7 +408,11 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         var currentValue = configEntry.BoxedValue is KeyCode bValue ? bValue : KeyCode.None;
 
                         if (configEntry is ConfigEntry<KeyCode> entry)
-                            ModdedKeybinds.TryAdd(entry, modName);
+                        {
+                            ModKeyToName item = new(entry, modName);
+                            ModdedKeybinds.Add(item);
+                        }
+                            
 
                         SettingsHandlerUtility.AddKeybindToTab(configEntry.Definition.Key, defaultValue, modName, currentValue, newVal => configEntry.BoxedValue = newVal);
                     }

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -112,13 +112,6 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                 .SetPosition(new Vector2(225, -180))
                 .SetWidth(200);
 
-
-            modSettingsPage.SetBackButton(backButton.GetComponent<Button>()); // sadly backButton.Button doesn't work cause Awake have not being called yet
-
-            MenuAPI.CreateText("Search")
-                .ParentTo(modSettingsPage)
-                .SetPosition(new Vector2(90, -210));
-
             var content = new GameObject("Content")
                 .AddComponent<PeakElement>()
                 .ParentTo(modSettingsPage)
@@ -129,14 +122,49 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                 .SetSize(new Vector2(1360, 980));
 
             var settingsMenu = content.gameObject.AddComponent<ModdedSettingsMenu>();
+            settingsMenu.MainPage = modSettingsPage;
 
+            if (pauseMenuHandler != null)
+            {
+                var controlsButton = MenuAPI.CreateMenuButton("MOD CONTROLS")
+                .SetLocalizationIndex("MOD CONTROLS") //localization should exist from controls page builder
+                .SetColor(new Color(0.3919f, 0.1843f, 0.6235f)) //same purple as default controls button
+                .ParentTo(modSettingsPage)
+                .SetPosition(new Vector2(225, -240))
+                .SetWidth(220);
 
-            var textInput = MenuAPI.CreateTextInput("SearchInput")
+                controlsButton.OnClick(() =>
+                {
+                    pauseMenuHandler.TransistionToPage(ModdedControlsMenu.Instance.MainPage, new SetActivePageTransistion());
+                });
+
+                MenuAPI.CreateText("Search")
+                .ParentTo(modSettingsPage)
+                .SetPosition(new Vector2(90, -275));
+
+                var textInput = MenuAPI.CreateTextInput("SearchInput")
+                .ParentTo(modSettingsPage)
+                .SetSize(new Vector2(300, 70))
+                .SetPosition(new Vector2(230, -360))
+                .SetPlaceholder("Search here")
+                .OnValueChanged(settingsMenu.SetSearch);
+            }
+            else
+            {
+                MenuAPI.CreateText("Search")
+                .ParentTo(modSettingsPage)
+                .SetPosition(new Vector2(90, -210));
+
+                var textInput = MenuAPI.CreateTextInput("SearchInput")
                 .ParentTo(modSettingsPage)
                 .SetSize(new Vector2(300, 70))
                 .SetPosition(new Vector2(230, -300))
                 .SetPlaceholder("Search here")
                 .OnValueChanged(settingsMenu.SetSearch);
+            }
+
+
+            modSettingsPage.SetBackButton(backButton.GetComponent<Button>()); // sadly backButton.Button doesn't work cause Awake have not being called yet
 
             var horizontalTabs = new GameObject("TABS")
                 .ParentTo(content)
@@ -239,23 +267,33 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                 .SetLocalizationIndex("BACK") // Peak already have a "BACK" official translation, so let's just use it
                 .SetColor(new Color(1, 0.5f, 0.2f))
                 .ParentTo(modControlsPage)
-                .SetPosition(new Vector2(225, -230))
+                .SetPosition(new Vector2(225, -280))
                 .SetWidth(200);
+
+            var modSettingsButton = MenuAPI.CreateMenuButton("MOD SETTINGS")
+                .SetLocalizationIndex("MOD SETTINGS") //re-use existing localization from settings builder
+                .SetColor(new Color(0.15f, 0.75f, 0.85f))
+                .ParentTo(modControlsPage)
+                .SetPosition(new Vector2(225, -160))
+                .SetWidth(220)
+                .OnClick(() =>
+                {
+                    pauseMenuHandler.TransistionToPage(ModdedSettingsMenu.Instance.MainPage, new SetActivePageTransistion());
+                });
 
             var restoreAllButton = MenuAPI.CreateMenuButton("Restore Defaults")
                 .SetLocalizationIndex("RESTOREDEFAULTS") // Peak has an official translation for this as well
                 .SetColor(new Color(0.3919f, 0.1843f, 0.6235f)) //same as default restore defaults button
                 .ParentTo(modControlsPage)
-                .SetPosition(new Vector2(225, -160))
-                .SetWidth(300);
-
-            restoreAllButton.OnClick(controlsMenu.OnResetClicked);
+                .SetPosition(new Vector2(225, -220))
+                .SetWidth(300)
+                .OnClick(controlsMenu.OnResetClicked);
 
             modControlsPage.SetBackButton(backButton.GetComponent<Button>()); // sadly backButton.Button doesn't work cause Awake have not being called yet
 
             MenuAPI.CreateText("Search")
                 .ParentTo(modControlsPage)
-                .SetPosition(new Vector2(55, -255));
+                .SetPosition(new Vector2(55, -305));
 
             var content = new GameObject("Content")
                 .AddComponent<PeakElement>()
@@ -276,7 +314,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
             var textInput = MenuAPI.CreateTextInput("SearchInput")
                 .ParentTo(modControlsPage)
                 .SetSize(new Vector2(300, 70))
-                .SetPosition(new Vector2(200, -340))
+                .SetPosition(new Vector2(200, -390))
                 .SetPlaceholder("Search here")
                 .OnValueChanged(controlsMenu.SetSearch);
 
@@ -286,17 +324,17 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                 .ParentTo(parent)
                 .OnClick(() =>
                 {
-                    var handler = pauseMenuHandler as UIPageHandler ?? pauseMenuHandler;
-
-                    handler?.TransistionToPage(modControlsPage, new SetActivePageTransistion());
+                    pauseMenuHandler.TransistionToPage(modControlsPage, new SetActivePageTransistion());
                 });
 
             modControlsPage.gameObject.SetActive(false);
             modControlsButton?.SetPosition(new Vector2(205, -291))
-                .SetWidth(220);  
+                .SetWidth(220);
         }
 
+        //settings menu builder
         MenuAPI.AddToSettingsMenu(builderDelegate);
+        //controls menu builder
         MenuAPI.AddToControlsMenu(controlsBuilder);
     }
 

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -402,7 +402,22 @@ public partial class ModConfigPlugin : BaseUnityPlugin
 
                         SettingsHandlerUtility.AddFloatToTab(configEntry.Definition.Key, defaultValue, modName, minValue, maxValue, currentValue, newVal => configEntry.BoxedValue = newVal);
                     }
+                    else if (configEntry.SettingType == typeof(double))
+                    {
+                        var defaultValue = configEntry.DefaultValue is double cValue ? cValue : 0f;
+                        var currentValue = configEntry.BoxedValue is double bValue ? bValue : 0f;
 
+                        float minValue = 0f;
+                        float maxValue = 1000f;
+
+                        if (configEntry.Description.AcceptableValues is AcceptableValueRange<double> range)
+                        {
+                            minValue = Convert.ToSingle(range.MinValue);
+                            maxValue = Convert.ToSingle(range.MaxValue);
+                        }
+
+                        SettingsHandlerUtility.AddDoubleToTab(configEntry.Definition.Key, defaultValue, modName, minValue, maxValue, currentValue, newVal => configEntry.BoxedValue = newVal);
+                    }
                     else if (configEntry.SettingType == typeof(int))
                     {
                         var defaultValue = configEntry.DefaultValue is int cValue ? cValue : 0;
@@ -415,7 +430,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         var currentValue = configEntry.BoxedValue is string bValue ? bValue : "";
 
                         //checking if default value matches key path pattern
-                        if(defaultValue.Length > 4)
+                        if (defaultValue.Length > 4)
                         {
                             if (IsValidPath(defaultValue))
                             {
@@ -423,8 +438,6 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                                 ModdedKeys.Add(item);
                                 Log.LogDebug($"String config with default - {defaultValue} is detected as InputAction path");
                             }
-                            else
-                                Log.LogDebug($"String config with default - {defaultValue} is NOT detected as InputAction path");
                         }
 
                         //dropdown box for acceptablevalue list
@@ -448,7 +461,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         {
                             ModKeyToName item = new(entry, modName);
                             ModdedKeys.Add(item);
-                        }    
+                        }
 
                         SettingsHandlerUtility.AddKeybindToTab(configEntry.Definition.Key, defaultValue, modName, currentValue, newVal => configEntry.BoxedValue = newVal);
                     }

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -120,10 +120,10 @@ public partial class ModConfigPlugin : BaseUnityPlugin
 
             var backButton = MenuAPI.CreateMenuButton("Back")
                 .SetLocalizationIndex("BACK") // Peak already have a "BACK" official translation, so let's just use it
-                .SetColor(new Color(1, 0.5f, 0.2f))
+                .SetColor(new Color(0.5189f, 0.1297f, 0.1718f)) //match vanilla back
                 .ParentTo(modSettingsPage)
-                .SetPosition(new Vector2(225, -180))
-                .SetWidth(200);
+                .SetPosition(new Vector2(120f, -160f))
+                .SetWidth(120f);
 
             var content = new GameObject("Content")
                 .AddComponent<PeakElement>()
@@ -141,40 +141,27 @@ public partial class ModConfigPlugin : BaseUnityPlugin
             {
                 var controlsButton = MenuAPI.CreateMenuButton("MOD CONTROLS")
                 .SetLocalizationIndex("MOD CONTROLS") //localization should exist from controls page builder
-                .SetColor(new Color(0.3919f, 0.1843f, 0.6235f)) //same purple as default controls button
+                .SetColor(new Color(0.185f, 0.394f, 0.6226f)) //same blue as main menu settings button
                 .ParentTo(modSettingsPage)
-                .SetPosition(new Vector2(225, -240))
-                .SetWidth(220);
+                .SetPosition(new Vector2(285f, -160f))
+                .SetWidth(200);
 
                 controlsButton.OnClick(() =>
                 {
                     pauseMenuHandler.TransistionToPage(ModdedControlsMenu.Instance.MainPage, new SetActivePageTransistion());
                 });
-
-                MenuAPI.CreateText("Search")
-                .ParentTo(modSettingsPage)
-                .SetPosition(new Vector2(90, -275));
-
-                var textInput = MenuAPI.CreateTextInput("SearchInput")
-                .ParentTo(modSettingsPage)
-                .SetSize(new Vector2(300, 70))
-                .SetPosition(new Vector2(230, -360))
-                .SetPlaceholder("Search here")
-                .OnValueChanged(settingsMenu.SetSearch);
             }
-            else
-            {
-                MenuAPI.CreateText("Search")
-                .ParentTo(modSettingsPage)
-                .SetPosition(new Vector2(90, -210));
 
-                var textInput = MenuAPI.CreateTextInput("SearchInput")
+            MenuAPI.CreateText("Search")
                 .ParentTo(modSettingsPage)
-                .SetSize(new Vector2(300, 70))
-                .SetPosition(new Vector2(230, -300))
-                .SetPlaceholder("Search here")
-                .OnValueChanged(settingsMenu.SetSearch);
-            }
+                .SetPosition(new Vector2(65f, -190f));
+
+            var textInput = MenuAPI.CreateTextInput("SearchInput")
+            .ParentTo(modSettingsPage)
+            .SetSize(new Vector2(300, 70))
+            .SetPosition(new Vector2(215, -275))
+            .SetPlaceholder("Search here")
+            .OnValueChanged(settingsMenu.SetSearch);
 
 
             modSettingsPage.SetBackButton(backButton.GetComponent<Button>()); // sadly backButton.Button doesn't work cause Awake have not being called yet
@@ -182,14 +169,34 @@ public partial class ModConfigPlugin : BaseUnityPlugin
             var horizontalTabs = new GameObject("TABS")
                 .ParentTo(content)
                 .AddComponent<PeakHorizontalTabs>();
+            horizontalTabs.RectTransform.anchoredPosition = new(110f, 0f);
+            horizontalTabs.RectTransform.anchorMax = new(0.92f, 1f); //give space for labels
+
+            var modTabsLabel = MenuAPI.CreateText("MODS")
+                .ParentTo(content)
+                .SetPosition(new(4, 10));
+
+            var sectionTabsLabel = MenuAPI.CreateText("SECTIONS")
+                .ParentTo(content)
+                .SetPosition(new(4, -50));
+
+            var sectionTabs = new GameObject("SectionTabs")
+                .ParentTo(content)
+                .AddComponent<PeakHorizontalTabs>();
+            sectionTabs.RectTransform.anchoredPosition = new(175f, -55f);
+            sectionTabs.RectTransform.anchorMax = new(0.87f, 1f);
 
             var moddedSettingsTABS = horizontalTabs.gameObject.AddComponent<ModdedSettingsTABS>();
             moddedSettingsTABS.SettingsMenu = settingsMenu;
 
+            var modSectionTABS = sectionTabs.gameObject.AddComponent<ModdedSettingsSectionTABS>();
+            modSectionTABS.SettingsMenu = settingsMenu;
+            settingsMenu.SectionTabController = sectionTabs;
+
             var tabContent = MenuAPI.CreateScrollableContent("TabContent")
                 .ParentTo(content)
                 .ExpandToParent()
-                .SetOffsetMax(new Vector2(0, -60f));
+                .SetOffsetMax(new Vector2(0, -110f));
 
             settingsMenu.Content = tabContent.Content;
             settingsMenu.Tabs = moddedSettingsTABS;
@@ -278,16 +285,16 @@ public partial class ModConfigPlugin : BaseUnityPlugin
 
             var backButton = MenuAPI.CreateMenuButton("Back (Controls)")
                 .SetLocalizationIndex("BACK") // Peak already have a "BACK" official translation, so let's just use it
-                .SetColor(new Color(1, 0.5f, 0.2f))
+                .SetColor(new Color(0.5189f, 0.1297f, 0.1718f)) //match vanilla back
                 .ParentTo(modControlsPage)
-                .SetPosition(new Vector2(225, -280))
-                .SetWidth(200);
+                .SetPosition(new Vector2(120f, -160f))
+                .SetWidth(120f);
 
             var modSettingsButton = MenuAPI.CreateMenuButton("MOD SETTINGS")
                 .SetLocalizationIndex("MOD SETTINGS") //re-use existing localization from settings builder
-                .SetColor(new Color(0.15f, 0.75f, 0.85f))
+                .SetColor(new Color(0.185f, 0.394f, 0.6226f)) //same blue as main menu settings button
                 .ParentTo(modControlsPage)
-                .SetPosition(new Vector2(225, -160))
+                .SetPosition(new Vector2(285f, -160f))
                 .SetWidth(220)
                 .OnClick(() =>
                 {
@@ -306,7 +313,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
 
             MenuAPI.CreateText("Search")
                 .ParentTo(modControlsPage)
-                .SetPosition(new Vector2(55, -305));
+                .SetPosition(new Vector2(65f, -245f));
 
             var content = new GameObject("Content")
                 .AddComponent<PeakElement>()
@@ -327,7 +334,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
             var textInput = MenuAPI.CreateTextInput("SearchInput")
                 .ParentTo(modControlsPage)
                 .SetSize(new Vector2(300, 70))
-                .SetPosition(new Vector2(200, -390))
+                .SetPosition(new Vector2(215f, -330f))
                 .SetPlaceholder("Search here")
                 .OnValueChanged(controlsMenu.SetSearch);
 
@@ -369,6 +376,8 @@ public partial class ModConfigPlugin : BaseUnityPlugin
     {
         foreach (var (modName, configEntryBases) in GetModConfigEntries())
         {
+            ModSectionNames sectionTracker = ModSectionNames.SetMod(modName);
+
             foreach (var configEntry in configEntryBases)
             {
                 try
@@ -379,55 +388,25 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     else
                         EntriesProcessed.Add(configEntry);
 
-                    if (configEntry.SettingType == typeof(bool))
-                    {
-                        var defaultValue = configEntry.DefaultValue is bool dValue && dValue;
-                        var currentValue = configEntry.BoxedValue is bool bValue && bValue;
+                    sectionTracker.CheckSectionName(configEntry.Definition.Section);
 
-                        SettingsHandlerUtility.AddBoolToTab(configEntry.Definition.Key, defaultValue, modName, currentValue, newVal => configEntry.BoxedValue = newVal);
-                    }
+                    if (configEntry.SettingType == typeof(bool))
+                        SettingsHandlerUtility.AddBoolToTab(configEntry, modName, newVal => configEntry.BoxedValue = newVal);
                     else if (configEntry.SettingType == typeof(float))
                     {
-                        var defaultValue = configEntry.DefaultValue is float cValue ? cValue : 0f;
-                        var currentValue = configEntry.BoxedValue is float bValue ? bValue : 0f;
-
-                        float minValue = 0f;
-                        float maxValue = 1000f;
-
-                        if (configEntry.Description.AcceptableValues is AcceptableValueRange<float> range)
-                        {
-                            minValue = range.MinValue;
-                            maxValue = range.MaxValue;
-                        }
-
-                        SettingsHandlerUtility.AddFloatToTab(configEntry.Definition.Key, defaultValue, modName, minValue, maxValue, currentValue, newVal => configEntry.BoxedValue = newVal);
+                        SettingsHandlerUtility.AddFloatToTab(configEntry, modName, newVal => configEntry.BoxedValue = newVal);
                     }
                     else if (configEntry.SettingType == typeof(double))
                     {
-                        var defaultValue = configEntry.DefaultValue is double cValue ? cValue : 0f;
-                        var currentValue = configEntry.BoxedValue is double bValue ? bValue : 0f;
-
-                        float minValue = 0f;
-                        float maxValue = 1000f;
-
-                        if (configEntry.Description.AcceptableValues is AcceptableValueRange<double> range)
-                        {
-                            minValue = Convert.ToSingle(range.MinValue);
-                            maxValue = Convert.ToSingle(range.MaxValue);
-                        }
-
-                        SettingsHandlerUtility.AddDoubleToTab(configEntry.Definition.Key, defaultValue, modName, minValue, maxValue, currentValue, newVal => configEntry.BoxedValue = newVal);
+                        SettingsHandlerUtility.AddDoubleToTab(configEntry, modName, newVal => configEntry.BoxedValue = newVal);
                     }
                     else if (configEntry.SettingType == typeof(int))
                     {
-                        var defaultValue = configEntry.DefaultValue is int cValue ? cValue : 0;
-                        var currentValue = configEntry.BoxedValue is int bValue ? bValue : 0;
-                        SettingsHandlerUtility.AddIntToTab(configEntry.Definition.Key, defaultValue, modName, currentValue, newVal => configEntry.BoxedValue = newVal);
+                        SettingsHandlerUtility.AddIntToTab(configEntry, modName, newVal => configEntry.BoxedValue = newVal);
                     }
                     else if (configEntry.SettingType == typeof(string))
                     {
                         var defaultValue = configEntry.DefaultValue is string cValue ? cValue : "";
-                        var currentValue = configEntry.BoxedValue is string bValue ? bValue : "";
 
                         //checking if default value matches key path pattern
                         if (defaultValue.Length > 4)
@@ -443,38 +422,28 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         //dropdown box for acceptablevalue list
                         if (configEntry.Description.AcceptableValues is AcceptableValueList<string> stringList)
                         {
-                            SettingsHandlerUtility.AddEnumToTab(configEntry.Definition.Key, [.. stringList.AcceptableValues], modName, defaultValue, newVal =>
+                            SettingsHandlerUtility.AddEnumToTab(configEntry, modName, false, newVal =>
                             {
                                 configEntry.BoxedValue = newVal;
                             });
                             return;
                         }
 
-                        SettingsHandlerUtility.AddStringToTab(configEntry.Definition.Key, defaultValue, modName, currentValue, newVal => configEntry.BoxedValue = newVal);
+                        SettingsHandlerUtility.AddStringToTab(configEntry, modName, newVal => configEntry.BoxedValue = newVal);
                     }
                     else if (configEntry.SettingType == typeof(KeyCode))
                     {
-                        var defaultValue = configEntry.DefaultValue is KeyCode cValue ? cValue : KeyCode.None;
-                        var currentValue = configEntry.BoxedValue is KeyCode bValue ? bValue : KeyCode.None;
-
                         if (configEntry is ConfigEntry<KeyCode> entry)
                         {
                             ModKeyToName item = new(entry, modName);
                             ModdedKeys.Add(item);
                         }
 
-                        SettingsHandlerUtility.AddKeybindToTab(configEntry.Definition.Key, defaultValue, modName, currentValue, newVal => configEntry.BoxedValue = newVal);
+                        SettingsHandlerUtility.AddKeybindToTab(configEntry, modName, newVal => configEntry.BoxedValue = newVal);
                     }
                     else if (configEntry.SettingType.IsEnum)
                     {
-                        var defaultValue = configEntry.DefaultValue is object cValue ? cValue : Enum.ToObject(configEntry.SettingType, 0);
-                        var currentValue = configEntry.BoxedValue is object bValue ? bValue : Enum.ToObject(configEntry.SettingType, 0);
-
-                        var defaultValueName = Enum.GetName(configEntry.SettingType, defaultValue);
-                        var currentValueName = Enum.GetName(configEntry.SettingType, currentValue);
-                        var options = new List<string>(Enum.GetNames(configEntry.SettingType));
-
-                        SettingsHandlerUtility.AddEnumToTab(configEntry.Definition.Key, options, modName, currentValueName, newVal =>
+                        SettingsHandlerUtility.AddEnumToTab(configEntry, modName, true, newVal =>
                         {
                             if (Enum.TryParse(configEntry.SettingType, newVal, out var value))
                                 configEntry.BoxedValue = value;

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExDouble.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExDouble.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Unity.Mathematics;
+using Zorro.Settings;
+
+namespace PEAKLib.ModConfig.SettingOptions;
+
+internal class BepInExDouble(string displayName, double defaultValue = 0f, string categoryName = "Mods",
+    double minValue = 0f, double maxValue = 1f, double currentValue = 0f,
+    Action<double>? saveCallback = null,
+    Action<BepInExDouble>? onApply = null) : FloatSetting, IBepInExProperty, IExposedSetting
+{
+    public override void Load(ISettingsSaveLoad loader)
+    {
+        Value = Convert.ToSingle(currentValue);
+
+        float2 minMaxValue = GetMinMaxValue();
+        MinValue = minMaxValue.x;
+        MaxValue = minMaxValue.y;
+    }
+
+    public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
+    public override void ApplyValue() => onApply?.Invoke(this);
+    public string GetDisplayName() => displayName;
+    public string GetCategory() => categoryName;
+    protected override float GetDefaultValue() => Convert.ToSingle(defaultValue);
+    protected override float2 GetMinMaxValue() => new(Convert.ToSingle(minValue), Convert.ToSingle(maxValue));
+}
+

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExEnum.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExEnum.cs
@@ -17,12 +17,17 @@ internal class BepInExEnum(ConfigEntryBase entryBase, string category = "Mods", 
 
     public string Value { get; protected set; } = "";
 
-    public override void Load(ISettingsSaveLoad loader)
+    public void RefreshValueFromConfig()
     {
         if (isEnum)
             Value = Enum.GetName(entryBase.SettingType, entryBase.BoxedValue is object bValue ? bValue : Enum.ToObject(entryBase.SettingType, 0));
         else
             Value = GetCurrentValue<string>(entryBase);
+    }
+
+    public override void Load(ISettingsSaveLoad loader)
+    {
+        RefreshValueFromConfig();
     }
 
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExFloat.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExFloat.cs
@@ -1,17 +1,20 @@
-﻿using System;
+﻿using BepInEx.Configuration;
+using System;
 using Unity.Mathematics;
 using Zorro.Settings;
+using static PEAKLib.ModConfig.SettingsHandlerUtility;
 
 namespace PEAKLib.ModConfig.SettingOptions;
 
-internal class BepInExFloat(string displayName, float defaultValue = 0f, string categoryName = "Mods",
-    float minValue = 0f, float maxValue = 1f, float currentValue = 0f,
+internal class BepInExFloat(ConfigEntryBase entryBase, string categoryName = "Mods",
     Action<float>? saveCallback = null,
     Action<BepInExFloat>? onApply = null) : FloatSetting, IBepInExProperty, IExposedSetting
 {
+    ConfigEntryBase IBepInExProperty.ConfigBase { get => entryBase; }
+
     public override void Load(ISettingsSaveLoad loader)
     {
-        Value = currentValue;
+        Value = GetCurrentValue<float>(entryBase);
 
         float2 minMaxValue = GetMinMaxValue();
         MinValue = minMaxValue.x;
@@ -20,9 +23,16 @@ internal class BepInExFloat(string displayName, float defaultValue = 0f, string 
 
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
     public override void ApplyValue() => onApply?.Invoke(this);
-    public string GetDisplayName() => displayName;
+    public void RefreshValueFromConfig() => Value = GetCurrentValue<float>(entryBase);
+    public string GetDisplayName() => entryBase.Definition.Key;
     public string GetCategory() => categoryName;
-    protected override float GetDefaultValue() => defaultValue;
-    protected override float2 GetMinMaxValue() => new(minValue, maxValue);
+    protected override float GetDefaultValue() => GetDefaultValue<float>(entryBase);
+    protected override float2 GetMinMaxValue()
+    {
+        if (TryGetMinMaxValue(entryBase, out float minValue, out float maxValue))
+            return new(minValue, maxValue);
+
+        return new(0f, 1000f);
+    }
 }
 

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExInt.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExInt.cs
@@ -49,6 +49,7 @@ internal class BepInExInt(ConfigEntryBase entryBase, string category = "Mods",
         }
     }
 
+    public void RefreshValueFromConfig() => Value = GetCurrentValue<int>(entryBase);
     public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<int>(entryBase);
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
     public override void ApplyValue() => onApply?.Invoke(this);

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExInt.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExInt.cs
@@ -1,18 +1,21 @@
-﻿using PEAKLib.ModConfig.SettingOptions.SettingUI;
+﻿using BepInEx.Configuration;
+using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using System;
 using TMPro;
 using UnityEngine;
 using Zorro.Core;
 using Zorro.Settings;
 using Zorro.Settings.UI;
+using static PEAKLib.ModConfig.SettingsHandlerUtility;
 using Object = UnityEngine.Object;
 
 namespace PEAKLib.ModConfig.SettingOptions;
 
-internal class BepInExInt(string displayName, string category, int defaultValue = 0, int currentValue = 0,
+internal class BepInExInt(ConfigEntryBase entryBase, string category = "Mods",
     Action<int>? saveCallback = null,
     Action<BepInExInt>? onApply = null) : IntSetting, IBepInExProperty, IExposedSetting
 {
+    ConfigEntryBase IBepInExProperty.ConfigBase { get => entryBase; }
     private static GameObject? _settingUICell = null;
     public static GameObject? SettingUICell
     {
@@ -46,11 +49,11 @@ internal class BepInExInt(string displayName, string category, int defaultValue 
         }
     }
 
-    public override void Load(ISettingsSaveLoad loader) => Value = currentValue;
+    public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<int>(entryBase);
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
     public override void ApplyValue() => onApply?.Invoke(this);
     public override GameObject? GetSettingUICell() => SettingUICell;
     public string GetCategory() => category;
-    public string GetDisplayName() => displayName;
-    protected override int GetDefaultValue() => defaultValue;
+    public string GetDisplayName() => entryBase.Definition.Key;
+    protected override int GetDefaultValue() => GetDefaultValue<int>(entryBase);
 }

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyCode.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyCode.cs
@@ -65,6 +65,7 @@ internal class BepInExKeyCode(ConfigEntryBase entryBase, string category = "Mods
     public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<KeyCode>(entryBase);
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
     public override void ApplyValue() => onApply?.Invoke(this);
+    public void RefreshValueFromConfig() => Value = GetCurrentValue<KeyCode>(entryBase);
     public override GameObject? GetSettingUICell() => SettingUICell;
     public string GetCategory() => category;
     public string GetDisplayName() => entryBase.Definition.Key;

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyCode.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyCode.cs
@@ -1,4 +1,5 @@
-﻿using PEAKLib.ModConfig.SettingOptions.SettingUI;
+﻿using BepInEx.Configuration;
+using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using System;
 using TMPro;
 using UnityEngine;
@@ -7,13 +8,15 @@ using Zorro.Core;
 using Zorro.Settings;
 using Zorro.Settings.UI;
 using Object = UnityEngine.Object;
+using static PEAKLib.ModConfig.SettingsHandlerUtility;
 
 namespace PEAKLib.ModConfig.SettingOptions;
 
-internal class BepInExKeyCode(string displayName, string category, KeyCode defaultValue = KeyCode.None, KeyCode currentValue = KeyCode.None,
+internal class BepInExKeyCode(ConfigEntryBase entryBase, string category = "Mods",
     Action<KeyCode>? saveCallback = null,
     Action<BepInExKeyCode>? onApply = null) : Setting, IBepInExProperty, IExposedSetting
 {
+    ConfigEntryBase IBepInExProperty.ConfigBase { get => entryBase; }
     public KeyCode Value { get; set; }
 
     private static GameObject? _settingUICell = null;
@@ -59,13 +62,13 @@ internal class BepInExKeyCode(string displayName, string category, KeyCode defau
         }
     }
 
-    public override void Load(ISettingsSaveLoad loader) => Value = currentValue;
+    public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<KeyCode>(entryBase);
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
     public override void ApplyValue() => onApply?.Invoke(this);
     public override GameObject? GetSettingUICell() => SettingUICell;
     public string GetCategory() => category;
-    public string GetDisplayName() => displayName;
-    protected KeyCode GetDefaultValue() => defaultValue;
+    public string GetDisplayName() => entryBase.Definition.Key;
+    protected KeyCode GetDefaultValue() => GetDefaultValue<KeyCode>(entryBase);
 
     public override Zorro.Settings.DebugUI.SettingUI GetDebugUI(ISettingHandler settingHandler)
     {

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExOffOn.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExOffOn.cs
@@ -1,17 +1,20 @@
-﻿using System;
+﻿using BepInEx.Configuration;
+using System;
 using System.Collections.Generic;
 using UnityEngine.Localization;
 using Zorro.Settings;
+using static PEAKLib.ModConfig.SettingsHandlerUtility;
 
 namespace PEAKLib.ModConfig.SettingOptions;
 
-internal class BepInExOffOn(string displayName, bool defaultValue = false, string category = "Mods", bool currentValue = false, Action<bool>? saveCallback = null, Action<BepInExOffOn>? onApply = null) : OffOnSetting, IBepInExProperty, IExposedSetting
+internal class BepInExOffOn(ConfigEntryBase entryBase, string category = "Mods", Action<bool>? saveCallback = null, Action<BepInExOffOn>? onApply = null) : OffOnSetting, IBepInExProperty, IExposedSetting
 {
-    public override void Load(ISettingsSaveLoad loader) => Value = currentValue ? OffOnMode.ON : OffOnMode.OFF;
+    ConfigEntryBase IBepInExProperty.ConfigBase { get => entryBase; }
+    public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<bool>(entryBase) ? OffOnMode.ON : OffOnMode.OFF;
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value == OffOnMode.ON);
     public override void ApplyValue() => onApply?.Invoke(this);
-    protected override OffOnMode GetDefaultValue() => defaultValue == true ? OffOnMode.ON : OffOnMode.OFF;
-    public string GetDisplayName() => displayName;
+    protected override OffOnMode GetDefaultValue() => GetDefaultValue<bool>(entryBase) == true ? OffOnMode.ON : OffOnMode.OFF;
+    public string GetDisplayName() => entryBase.Definition.Key;
     public string GetCategory() => category;
     public override List<LocalizedString>? GetLocalizedChoices() => null;
 }

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExOffOn.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExOffOn.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx.Configuration;
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.Localization;
 using Zorro.Settings;
 using static PEAKLib.ModConfig.SettingsHandlerUtility;
@@ -12,6 +13,7 @@ internal class BepInExOffOn(ConfigEntryBase entryBase, string category = "Mods",
     ConfigEntryBase IBepInExProperty.ConfigBase { get => entryBase; }
     public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<bool>(entryBase) ? OffOnMode.ON : OffOnMode.OFF;
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value == OffOnMode.ON);
+    public void RefreshValueFromConfig() => Value = GetCurrentValue<bool>(entryBase) ? OffOnMode.ON : OffOnMode.OFF;
     public override void ApplyValue() => onApply?.Invoke(this);
     protected override OffOnMode GetDefaultValue() => GetDefaultValue<bool>(entryBase) == true ? OffOnMode.ON : OffOnMode.OFF;
     public string GetDisplayName() => entryBase.Definition.Key;

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExString.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExString.cs
@@ -64,6 +64,7 @@ internal class BepInExString(ConfigEntryBase entryBase, string category = "Mods"
     public string GetCategory() => category;
     public string GetDisplayName() => entryBase.Definition.Key;
     protected override string GetDefaultValue() => GetDefaultValue<string>(entryBase);
+    public void RefreshValueFromConfig() => Value = GetCurrentValue<string>(entryBase);
 }
 
 public class StringSettingUI : SettingInputUICell

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExString.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExString.cs
@@ -1,18 +1,22 @@
-﻿using System;
+﻿using BepInEx.Configuration;
+using System;
 using TMPro;
 using UnityEngine;
 using Zorro.Core;
 using Zorro.Settings;
 using Zorro.Settings.UI;
 using Object = UnityEngine.Object;
+using static PEAKLib.ModConfig.SettingsHandlerUtility;
 
 namespace PEAKLib.ModConfig.SettingOptions;
 
-internal class BepInExString(string displayName, string category, string defaultValue = "", string currentValue = "",
+internal class BepInExString(ConfigEntryBase entryBase, string category = "Mods",
     Action<string>? saveCallback = null,
     Action<BepInExString>? onApply = null) : StringSetting, IBepInExProperty, IExposedSetting
 {
-    public string PlaceholderText { get; set; } = defaultValue ?? "";
+    ConfigEntryBase IBepInExProperty.ConfigBase { get => entryBase; }
+
+    public string PlaceholderText { get; set; } = GetDefaultValue<string>(entryBase) ?? "";
     private static GameObject? _settingUICell = null;
     public static GameObject? SettingUICell
     {
@@ -53,13 +57,13 @@ internal class BepInExString(string displayName, string category, string default
         }
     }
 
-    public override void Load(ISettingsSaveLoad loader) => Value = currentValue;
+    public override void Load(ISettingsSaveLoad loader) => Value = GetCurrentValue<string>(entryBase);
     public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
     public override void ApplyValue() => onApply?.Invoke(this);
     public override GameObject? GetSettingUICell() => SettingUICell;
     public string GetCategory() => category;
-    public string GetDisplayName() => displayName;
-    protected override string GetDefaultValue() => defaultValue;
+    public string GetDisplayName() => entryBase.Definition.Key;
+    protected override string GetDefaultValue() => GetDefaultValue<string>(entryBase);
 }
 
 public class StringSettingUI : SettingInputUICell

--- a/src/PEAKLib.ModConfig/SettingsHandlerUtility.cs
+++ b/src/PEAKLib.ModConfig/SettingsHandlerUtility.cs
@@ -1,4 +1,5 @@
-﻿using PEAKLib.ModConfig.SettingOptions;
+﻿using BepInEx.Configuration;
+using PEAKLib.ModConfig.SettingOptions;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -7,62 +8,101 @@ namespace PEAKLib.ModConfig;
 
 internal static class SettingsHandlerUtility
 {
-    internal static void AddBoolToTab(string displayName, bool defaultValue, string tabName, bool currentValue = false, Action<bool>? saveCallback = null)
+    internal static void AddBoolToTab(ConfigEntryBase entry, string tabName, Action<bool>? saveCallback = null)
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
 
-        SettingsHandler.Instance.AddSetting(new BepInExOffOn(displayName, defaultValue, tabName, currentValue, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExOffOn(entry, tabName, saveCallback));
     }
 
-    internal static void AddFloatToTab(string displayName, float defaultValue,
-        string tabName, float minValue = 0f, float maxValue = 1f, float currentValue = 0f, Action<float>? applyCallback = null)
+    internal static void AddFloatToTab(ConfigEntryBase entry,
+        string tabName, Action<float>? applyCallback = null)
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
    
 
-        SettingsHandler.Instance.AddSetting(new BepInExFloat(displayName, defaultValue, tabName, minValue, maxValue, currentValue, applyCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExFloat(entry, tabName, applyCallback));
     }
-    internal static void AddDoubleToTab(string displayName, double defaultValue,
-       string tabName, double minValue = 0f, double maxValue = 1f, double currentValue = 0f, Action<double>? applyCallback = null)
+    internal static void AddDoubleToTab(ConfigEntryBase entry,
+        string tabName, Action<double>? applyCallback = null)
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
 
 
-        SettingsHandler.Instance.AddSetting(new BepInExDouble(displayName, defaultValue, tabName, minValue, maxValue, currentValue, applyCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExDouble(entry, tabName, applyCallback));
     }
 
-    internal static void AddIntToTab(string displayName, int defaultValue, string tabName, int currentValue = 0, Action<int>? saveCallback = null)
+    internal static void AddIntToTab(ConfigEntryBase entry, string tabName, Action<int>? saveCallback = null)
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
            
 
-        SettingsHandler.Instance.AddSetting(new BepInExInt(displayName, tabName, defaultValue, currentValue, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExInt(entry, tabName, saveCallback));
     }
 
-    internal static void AddStringToTab(string displayName, string defaultValue, string tabName, string currentValue = "", Action<string>? saveCallback = null)
+    internal static void AddStringToTab(ConfigEntryBase entry, string tabName, Action<string>? saveCallback = null)
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
 
-        SettingsHandler.Instance.AddSetting(new BepInExString(displayName, tabName, defaultValue, currentValue, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExString(entry, tabName, saveCallback));
     }
-    internal static void AddKeybindToTab(string displayName, KeyCode defaultValue, string tabName, KeyCode currentValue, Action<KeyCode>? saveCallback)
+    internal static void AddKeybindToTab(ConfigEntryBase entry, string tabName, Action<KeyCode>? saveCallback)
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
 
-        SettingsHandler.Instance.AddSetting(new BepInExKeyCode(displayName, tabName, defaultValue, currentValue, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExKeyCode(entry, tabName, saveCallback));
     }
 
-    internal static void AddEnumToTab(string displayName, List<string> options, string tabName, string currentValue, Action<string>? saveCallback) 
+    internal static void AddEnumToTab(ConfigEntryBase entry, string tabName, bool isEnum, Action<string>? saveCallback) 
     {
         if (SettingsHandler.Instance == null)
             throw new Exception("You're registering options too early! Use the Start() function to create new options!");
 
-        SettingsHandler.Instance.AddSetting(new BepInExEnum(displayName, options, currentValue, tabName, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExEnum(entry, tabName, isEnum, saveCallback));
+    }
+
+    public static T GetDefaultValue<T>(ConfigEntry<T> entry)
+    {
+        return (T)entry.DefaultValue;
+    }
+
+    public static T GetDefaultValue<T>(ConfigEntryBase entry)
+    {
+        return (T)entry.DefaultValue;
+    }
+
+    public static T GetCurrentValue<T>(ConfigEntryBase entry)
+    {
+        return (T)entry.BoxedValue;
+    }
+
+    public static List<T> GetAcceptableValues<T>(ConfigEntryBase entry) where T : IEquatable<T>
+    {
+        if (entry.Description.AcceptableValues is AcceptableValueList<T> valueList)
+        {
+            return [.. valueList.AcceptableValues];
+        }
+        else
+            return [];
+    }
+
+    public static bool TryGetMinMaxValue<T>(ConfigEntryBase entry, out T minValue, out T maxValue) where T : IComparable
+    {
+        minValue = default!;
+        maxValue = default!;
+        if (entry.Description.AcceptableValues is AcceptableValueRange<T> range)
+        {
+            minValue = range.MinValue;
+            maxValue = range.MaxValue;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/PEAKLib.ModConfig/SettingsHandlerUtility.cs
+++ b/src/PEAKLib.ModConfig/SettingsHandlerUtility.cs
@@ -24,6 +24,15 @@ internal static class SettingsHandlerUtility
 
         SettingsHandler.Instance.AddSetting(new BepInExFloat(displayName, defaultValue, tabName, minValue, maxValue, currentValue, applyCallback));
     }
+    internal static void AddDoubleToTab(string displayName, double defaultValue,
+       string tabName, double minValue = 0f, double maxValue = 1f, double currentValue = 0f, Action<double>? applyCallback = null)
+    {
+        if (SettingsHandler.Instance == null)
+            throw new Exception("You're registering options too early! Use the Start() function to create new options!");
+
+
+        SettingsHandler.Instance.AddSetting(new BepInExDouble(displayName, defaultValue, tabName, minValue, maxValue, currentValue, applyCallback));
+    }
 
     internal static void AddIntToTab(string displayName, int defaultValue, string tabName, int currentValue = 0, Action<int>? saveCallback = null)
     {

--- a/src/PEAKLib.UI/Elements/PeakHorizontalTabs.cs
+++ b/src/PEAKLib.UI/Elements/PeakHorizontalTabs.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 using UnityEngine.UI;
 using Zorro.UI;
 
@@ -13,9 +15,15 @@ namespace PEAKLib.UI.Elements;
 public class PeakHorizontalTabs : PeakElement
 {
     private RectTransform Content { get; set; } = null!;
+    /// <summary>
+    /// List of all Tabs (game objects) associated with this component
+    /// </summary>
+    public List<GameObject> Tabs = [];
+    private Color backgroundColor = new Color(0.1792453f, 0.1253449f, 0.09046815f, 0.7294118f);
 
     private void Awake()
     {
+        Tabs.Clear();
         RectTransform = GetComponent<RectTransform>();
 
         RectTransform.anchoredPosition = new Vector2(0, 0);
@@ -82,7 +90,7 @@ public class PeakHorizontalTabs : PeakElement
         Utilities.ExpandToParent(imageTransform);
 
         var image = imageTransform.GetComponent<Image>();
-        image.color = new Color(0.1792453f, 0.1253449f, 0.09046815f, 0.7294118f);
+        image.color = backgroundColor;
 
         var selected = new GameObject("Selected", typeof(RectTransform), typeof(Image))
             .ParentTo(gameObject.transform)
@@ -108,6 +116,61 @@ public class PeakHorizontalTabs : PeakElement
         peakText.TextMesh.alignment = TMPro.TextAlignmentOptions.Center;
         peakText.TextMesh.text = tabName;
 
+        Tabs.Add(gameObject);
         return gameObject;
+    }
+
+    private bool DoesTabExist(string tabName, out GameObject match)
+    {
+        match = null!;
+        if (string.IsNullOrEmpty(tabName))
+            return false;
+
+        match = Tabs.FirstOrDefault(x => x.name == tabName);
+
+        if (match == null)
+            UIPlugin.Log.LogWarning($"Unable to find existing tab by name: {tabName}");
+
+        return match != null;
+    }
+
+    /// <summary>
+    /// Deletes a tab from this Horizontal Tab. Needs to add your own component implementation of <see cref="TAB_Button"/>.
+    /// </summary>
+    /// <param name="tabName"></param>
+    /// <returns></returns>
+    public void DeleteTab(string tabName)
+    {
+        if (!DoesTabExist(tabName, out GameObject match))
+            return;
+
+        Destroy(match);
+        Tabs.Remove(match);
+    }
+
+    /// <summary>
+    /// Update name of existing tab from this Horizontal Tab. Needs to add your own component implementation of <see cref="TAB_Button"/>.
+    /// </summary>
+    /// <param currentName="currentName"></param>
+    /// <param newName="newName"></param>
+    /// <returns></returns>
+    public void UpdateName(string currentName, string newName)
+    {
+        if (!DoesTabExist(currentName, out GameObject match))
+            return;
+
+        match.gameObject.name = newName;
+        match.GetComponent<PeakText>().SetText(newName);
+    }
+
+    /// <summary>
+    /// Change background color of your Tab Elements
+    /// This must be defined before calling AddTab
+    /// </summary>
+    /// <param Color="color"></param>
+    /// <returns></returns>
+    public void SetBackgroundColor(Color color)
+    {
+        backgroundColor = color;
     }
 }

--- a/src/PEAKLib.UI/Elements/Settings/GenericBoolSetting.cs
+++ b/src/PEAKLib.UI/Elements/Settings/GenericBoolSetting.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine.Localization;
+using Zorro.Settings;
+
+namespace PEAKLib.UI.Elements.Settings;
+
+/// <summary>
+/// Creates an on/off setting that can be added to any of the vanilla setting tabs
+/// Category determines which tab to display the setting.
+/// Use the saveCallback action to use the new value in your code how you see fit.
+/// </summary>
+public class GenericBoolSetting(string displayName, bool defaultValue = false, SettingsCategory category = SettingsCategory.General, bool currentValue = false, Action<bool>? saveCallback = null, Action<GenericBoolSetting>? onApply = null) : OffOnSetting, IExposedSetting
+{
+    /// <summary>
+    /// Override for OffOnSetting.Load which is used by PEAK to load the setting.
+    /// </summary>
+    public override void Load(ISettingsSaveLoad loader) => Value = currentValue ? OffOnMode.ON : OffOnMode.OFF;
+
+    /// <summary>
+    /// Override for OffOnSetting.Save which is used by PEAK to save the setting.
+    /// </summary>
+    public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value == OffOnMode.ON);
+    /// <summary>
+    /// Override for OffOnSetting.ApplyValue which is used by PEAK to apply the new value.
+    /// </summary>
+    public override void ApplyValue() => onApply?.Invoke(this);
+    /// <summary>
+    /// Override for OffOnSetting.GetDisplayName which is used by PEAK to display the name of the setting.
+    /// </summary>
+    protected override OffOnMode GetDefaultValue() => defaultValue == true ? OffOnMode.ON : OffOnMode.OFF;
+    /// <summary>
+    /// Override for OffOnSetting.GetDisplayName which is used by PEAK to display the name of the setting.
+    /// </summary>
+    public string GetDisplayName() => displayName;
+    /// <summary>
+    /// Override for OffOnSetting.GetCategory which is used by PEAK to get the category of the setting.
+    /// The category is used to determine which tab should display this setting
+    /// </summary>
+    public string GetCategory() => category.ToString();
+    /// <summary>
+    /// Override for EnumSetting.GetLocalizedChoices which is used by PEAK to get localized choices for this setting.
+    /// Not currently doing anything.
+    /// </summary>
+    public override List<LocalizedString>? GetLocalizedChoices() => null!;
+
+    /// <summary>
+    /// Override for EnumSetting.GetLocalizedChoices which is used by PEAK to get localized choices for this setting.
+    /// Not currently doing anything.
+    /// </summary>
+    public override List<string> GetUnlocalizedChoices()
+    {
+        return ["OFF", "ON"];
+    }
+}

--- a/src/PEAKLib.UI/Elements/Settings/GenericEnumSetting.cs
+++ b/src/PEAKLib.UI/Elements/Settings/GenericEnumSetting.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Localization;
+using Zorro.Core;
+using Zorro.Settings;
+
+namespace PEAKLib.UI.Elements.Settings;
+
+/// <summary>
+/// Creates an enum type setting that can be added to any of the vanilla setting tabs
+/// Category determines which tab to display the setting.
+/// Use the saveCallback action to use the new value in your code how you see fit.
+/// </summary>
+public class GenericEnumSetting<T>(string displayName, T currentValue, T defaultValue, SettingsCategory category = SettingsCategory.General, Action<T>? saveCallback = null, Action<GenericEnumSetting<T>>? onApply = null) : EnumSetting<T>, IExposedSetting where T : unmanaged, Enum
+{
+    /// <summary>
+    /// Override for OffOnSetting.Load which is used by PEAK to load the setting.
+    /// </summary>
+    public override void Load(ISettingsSaveLoad loader) => Value = currentValue;
+
+    /// <summary>
+    /// Override for Save which is used by PEAK to save the setting.
+    /// </summary>
+    public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
+    /// <summary>
+    /// Override for GetSettingUICell which is used by PEAK as a template to create the setting type.
+    /// </summary>
+    public override GameObject GetSettingUICell() => SingletonAsset<InputCellMapper>.Instance.EnumSettingCell;
+    /// <summary>
+    /// Override for ApplyValue which is used by PEAK to apply the new value.
+    /// </summary>
+    public override void ApplyValue() => onApply?.Invoke(this);
+    /// <summary>
+    /// Override for GetDisplayName which is used by PEAK to display the name of the setting.
+    /// </summary>
+    protected override T GetDefaultValue() => defaultValue;
+    /// <summary>
+    /// Override for GetDisplayName which is used by PEAK to display the name of the setting.
+    /// </summary>
+    public string GetDisplayName() => displayName;
+    /// <summary>
+    /// Override for GetCategory which is used by PEAK to get the category of the setting.
+    /// The category is used to determine which tab should display this setting
+    /// </summary>
+    public string GetCategory() => category.ToString();
+    /// <summary>
+    /// Override for GetLocalizedChoices which is used by PEAK to get localized choices for this setting.
+    /// Not currently doing anything.
+    /// </summary>
+    public override List<LocalizedString>? GetLocalizedChoices() => null!;
+
+    /// <summary>
+    /// Override for GetUnlocalizedChoices which is used by PEAK to display the unlocalized choices for this setting.
+    /// This is the string representation of your enum's possible values
+    /// </summary>
+    public override List<string> GetUnlocalizedChoices() => [.. Enum.GetNames(typeof(T))];
+
+    /// <summary>
+    /// Override for GetDebugUI which is used by PEAK to create a debug setting cell
+    /// Set to null so that no debug setting is made
+    /// </summary>
+    public override Zorro.Settings.DebugUI.SettingUI GetDebugUI(ISettingHandler settingHandler) => null!;
+}

--- a/src/PEAKLib.UI/Elements/Settings/GenericFloatSetting.cs
+++ b/src/PEAKLib.UI/Elements/Settings/GenericFloatSetting.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Unity.Mathematics;
+using Zorro.Settings;
+
+namespace PEAKLib.UI.Elements.Settings;
+
+/// <summary>
+/// Creates a slider setting that can be added to any of the vanilla setting tabs
+/// Category determines which tab to display the setting.
+/// Use the saveCallback action to use the new value in your code how you see fit.
+/// Can be used by other types than float, just translate your values to float on initialization and back from float on callback methods
+/// </summary>
+public class GenericFloatSetting(string displayName, float defaultValue = 0f, SettingsCategory category = SettingsCategory.General,
+    float minValue = 0f, float maxValue = 1f, float currentValue = 0f,
+    Action<float>? saveCallback = null,
+    Action<GenericFloatSetting>? onApply = null) : FloatSetting, IExposedSetting
+{
+    /// <summary>
+    /// Override for FloatSetting.Load which is used by PEAK to load the setting.
+    /// </summary>
+    public override void Load(ISettingsSaveLoad loader)
+    {
+        Value = currentValue;
+
+        float2 minMaxValue = GetMinMaxValue();
+        MinValue = minMaxValue.x;
+        MaxValue = minMaxValue.y;
+    }
+
+    /// <summary>
+    /// Override for FloatSetting.Save which is used by PEAK to save the setting.
+    /// </summary>
+    public override void Save(ISettingsSaveLoad saver) => saveCallback?.Invoke(Value);
+
+    /// <summary>
+    /// Override for FloatSetting.ApplyValue which is used by PEAK to apply the new value.
+    /// </summary>
+    public override void ApplyValue() => onApply?.Invoke(this);
+
+    /// <summary>
+    /// Override for FloatSetting.GetDisplayName which is used by PEAK to display the name of the setting.
+    /// </summary>
+    public string GetDisplayName() => displayName;
+
+    /// <summary>
+    /// Override for FloatSetting.GetCategory which is used by PEAK to get the category of the setting.
+    /// The category is used to determine which tab should display this setting
+    /// </summary>
+    public string GetCategory() => category.ToString();
+
+    /// <summary>
+    /// Override for FloatSetting.GetDefaultValue which is used by PEAK to get the default value of the setting.
+    /// </summary>
+    protected override float GetDefaultValue() => defaultValue;
+
+    /// <summary>
+    /// Override for FloatSetting.GetMinMaxValue which is used by PEAK to get the minimum and maximum values of the setting.
+    /// Min and Max values are used for the setting's slider
+    /// </summary>
+    protected override float2 GetMinMaxValue() => new(minValue, maxValue);
+}

--- a/src/PEAKLib.UI/Elements/Templates.cs
+++ b/src/PEAKLib.UI/Elements/Templates.cs
@@ -16,4 +16,14 @@ public static class Templates
     /// Reference to PEAK settings cell prefab.
     /// </summary>
     public static GameObject? SettingsCellPrefab { get; internal set; }
+
+    /// <summary>
+    /// Reference to PEAK Reset Bind Button prefab.
+    /// </summary>
+    public static GameObject? ResetBindButton { get; internal set; }
+    /// <summary>
+    /// Reference to PEAK Bind Warning (Controls) Button prefab.
+    /// </summary>
+    public static GameObject? BindWarningButton { get; internal set; }
+
 }

--- a/src/PEAKLib.UI/Elements/Templates.cs
+++ b/src/PEAKLib.UI/Elements/Templates.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using TMPro;
+using UnityEngine;
 
 namespace PEAKLib.UI.Elements;
 
@@ -9,21 +10,64 @@ public static class Templates
 {
     /// <summary>
     /// Reference to PEAK back button, used as a template for buttons.
+    /// Reference grabbed at MainMenu.Start
     /// </summary>
     public static GameObject? ButtonTemplate { get; internal set; }
 
     /// <summary>
     /// Reference to PEAK settings cell prefab.
+    /// Used in ModConfig's Mod Settings Page
+    /// Reference grabbed at MainMenu.Start
     /// </summary>
     public static GameObject? SettingsCellPrefab { get; internal set; }
 
     /// <summary>
     /// Reference to PEAK Reset Bind Button prefab.
+    /// Used in ModConfig's Mod Controls Page
+    /// Reference grabbed at MainMenu.Start
     /// </summary>
     public static GameObject? ResetBindButton { get; internal set; }
     /// <summary>
     /// Reference to PEAK Bind Warning (Controls) Button prefab.
+    /// Used in ModConfig's Mod Controls Page
+    /// Reference grabbed at PauseMenuControlsPage.Awake
     /// </summary>
     public static GameObject? BindWarningButton { get; internal set; }
+
+    /// <summary>
+    /// Reference to PEAK Keyboard Sprite Sheet.
+    /// This can be used to display keyboard sprites with a TMP_SpriteAnimator
+    /// Used with ModConfig's Mod Controls Page
+    /// Reference grabbed at PauseMenuControlsPage.Awake
+    /// </summary>
+    public static TMP_SpriteAsset? KeyboardSpriteSheet { get; internal set; }
+
+    /// <summary>
+    /// Reference to PEAK Xbox Controller Sprite Sheet.
+    /// This can be used to display keyboard sprites with a TMP_SpriteAnimator
+    /// Reference grabbed at PauseMenuControlsPage.Awake
+    /// </summary>
+    public static TMP_SpriteAsset? XboxSpriteSheet { get; internal set; }
+
+    /// <summary>
+    /// Reference to PEAK PS4 Controller Sprite Sheet.
+    /// This can be used to display keyboard sprites with a TMP_SpriteAnimator
+    /// Reference grabbed at PauseMenuControlsPage.Awake
+    /// </summary>
+    public static TMP_SpriteAsset? PS4SpriteSheet { get; internal set; }
+
+    /// <summary>
+    /// Reference to PEAK PS5 Controller Sprite Sheet.
+    /// This can be used to display keyboard sprites with a TMP_SpriteAnimator
+    /// Reference grabbed at PauseMenuControlsPage.Awake
+    /// </summary>
+    public static TMP_SpriteAsset? PS5SpriteSheet { get; internal set; }
+
+    /// <summary>
+    /// Reference to PEAK Switch Controller Sprite Sheet.
+    /// This can be used to display keyboard sprites with a TMP_SpriteAnimator
+    /// Reference grabbed at PauseMenuControlsPage.Awake
+    /// </summary>
+    public static TMP_SpriteAsset? SwitchSpriteSheet { get; internal set; }
 
 }

--- a/src/PEAKLib.UI/Hooks/MainMenuHooks.cs
+++ b/src/PEAKLib.UI/Hooks/MainMenuHooks.cs
@@ -22,9 +22,9 @@ static class PauseMenuHooks
     {
         var objects = Resources.FindObjectsOfTypeAll<GameObject>();
         Templates.SettingsCellPrefab = objects.First(n => n.name == "SettingsCell");
-        UIPlugin.Log.LogInfo($"SettingsCellPrefab is null - {Templates.SettingsCellPrefab == null}");
+        UIPlugin.Log.LogDebug($"SettingsCellPrefab is null - {Templates.SettingsCellPrefab == null}");
         var button = objects.First(n => n.name == "UI_MainMenuButton_LeaveGame (2)");
-        UIPlugin.Log.LogInfo($"button is null - {button == null}");
+        UIPlugin.Log.LogDebug($"button is null - {button == null}");
 
         if (Templates.SettingsCellPrefab == null || button == null)
         {
@@ -34,7 +34,7 @@ static class PauseMenuHooks
         }
 
         //instantiate as a new object to use as prefab because the reference we are grabbing will be destroyed at some point
-        Templates.ButtonTemplate = Object.Instantiate(button);
+        Templates.ButtonTemplate = Object.Instantiate(button)!;
         Templates.ButtonTemplate.name = "PeakUIButton";
 
         LocalizedText? locText =

--- a/src/PEAKLib.UI/Hooks/PauseMenuControlsPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuControlsPageHooks.cs
@@ -1,0 +1,57 @@
+﻿using MonoDetour;
+using MonoDetour.HookGen;
+using On.PauseMenuControlsPage;
+using PEAKLib.Core;
+using PEAKLib.UI.Elements;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Zorro.Core;
+
+namespace PEAKLib.UI.Hooks;
+
+[MonoDetourTargets(typeof(PauseMenuControlsPage))]
+static class PauseMenuControlsPageHooks
+{
+    [MonoDetourHookInitialize]
+    static void Init()
+    {
+        Awake.Prefix(Prefix_Start);
+    }
+
+    internal static bool InitComplete = false;
+    static void Prefix_Start(PauseMenuControlsPage self)
+    {
+        if (!InitComplete)
+        {
+            var control = self.transform.FindChildRecursive("UI_Control_KB_MoveForward").gameObject;
+            UIPlugin.Log.LogDebug($"control is null - {control == null}");
+
+            var rebind = control?.transform.Find("Rebind").gameObject;
+            var reset = control?.transform.Find("ResetButton").gameObject;
+            var warning = control?.transform.Find("Warning").gameObject;
+
+            List<GameObject> CannotBeNull = [control, rebind, reset, warning];
+
+            if (CannotBeNull.Any(o => o == null!))
+            {
+                ThrowHelper.ThrowIfArgumentNull(control, "Unable to get valid control gameobject for control button templates!");
+                ThrowHelper.ThrowIfArgumentNull(rebind, "Unable to get rebind button template!");
+                ThrowHelper.ThrowIfArgumentNull(reset, "Unable to get reset button template!");
+                ThrowHelper.ThrowIfArgumentNull(warning, "Unable to get bind warning object for template!");
+                return;
+            }
+
+            Templates.ResetBindButton = Object.Instantiate(reset)!;
+            Templates.ResetBindButton.name = "PeakUIResetBindButton";
+            Object.DontDestroyOnLoad(Templates.ResetBindButton);
+
+            Templates.BindWarningButton = Object.Instantiate(warning)!;
+            Templates.BindWarningButton.name = "PeakUIBindWarningButton";
+            Object.DontDestroyOnLoad(Templates.BindWarningButton);
+            InitComplete = true;
+        }
+
+        //MenuAPI.controlsMenuBuilderDelegate?.Invoke(self.gameObject.transform);
+    }
+}

--- a/src/PEAKLib.UI/Hooks/PauseMenuControlsPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuControlsPageHooks.cs
@@ -27,21 +27,22 @@ static class PauseMenuControlsPageHooks
             var control = self.transform.FindChildRecursive("UI_Control_KB_MoveForward").gameObject;
             UIPlugin.Log.LogDebug($"control is null - {control == null}");
 
-            var rebind = control?.transform.Find("Rebind").gameObject;
             var reset = control?.transform.Find("ResetButton").gameObject;
             var warning = control?.transform.Find("Warning").gameObject;
+            var inputIcon = control?.gameObject.GetComponentInChildren<InputIcon>();
 
-            List<GameObject> CannotBeNull = [control, rebind, reset, warning];
+            List<GameObject> CannotBeNull = [control, reset, warning];
 
-            if (CannotBeNull.Any(o => o == null!))
+            if (CannotBeNull.Any(o => o == null!) || inputIcon == null)
             {
                 ThrowHelper.ThrowIfArgumentNull(control, "Unable to get valid control gameobject for control button templates!");
-                ThrowHelper.ThrowIfArgumentNull(rebind, "Unable to get rebind button template!");
                 ThrowHelper.ThrowIfArgumentNull(reset, "Unable to get reset button template!");
                 ThrowHelper.ThrowIfArgumentNull(warning, "Unable to get bind warning object for template!");
+                ThrowHelper.ThrowIfArgumentNull(inputIcon, "Unable to get valid inputIcon for template!");
                 return;
             }
 
+            //Control Page Re-Used Buttons
             Templates.ResetBindButton = Object.Instantiate(reset)!;
             Templates.ResetBindButton.name = "PeakUIResetBindButton";
             Object.DontDestroyOnLoad(Templates.ResetBindButton);
@@ -49,9 +50,14 @@ static class PauseMenuControlsPageHooks
             Templates.BindWarningButton = Object.Instantiate(warning)!;
             Templates.BindWarningButton.name = "PeakUIBindWarningButton";
             Object.DontDestroyOnLoad(Templates.BindWarningButton);
+
+            //Sprite Sheets
+            Templates.PS5SpriteSheet = inputIcon!.ps5Sprites;
+            Templates.PS4SpriteSheet = inputIcon!.ps4Sprites;
+            Templates.XboxSpriteSheet = inputIcon!.xboxSprites;
+            Templates.SwitchSpriteSheet = inputIcon!.switchSprites;
+            Templates.KeyboardSpriteSheet = inputIcon!.keyboardSprites;
             InitComplete = true;
         }
-
-        //MenuAPI.controlsMenuBuilderDelegate?.Invoke(self.gameObject.transform);
     }
 }

--- a/src/PEAKLib.UI/Hooks/PauseMenuMainPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuMainPageHooks.cs
@@ -1,0 +1,24 @@
+﻿using MonoDetour;
+using MonoDetour.HookGen;
+using On.PauseMenuMainPage;
+
+
+namespace PEAKLib.UI.Hooks;
+
+[MonoDetourTargets(typeof(PauseMenuMainPage))]
+static class PauseMenuMainPageHooks
+{
+    internal static bool RunOnce = false;
+
+    [MonoDetourHookInitialize]
+    static void Init()
+    {
+        Start.Postfix(PostfixEnable);
+    }
+
+    private static void PostfixEnable(PauseMenuMainPage self)
+    {
+        var controls = self.transform.parent.Find("ControlsPage");
+        MenuAPI.controlsMenuBuilderDelegate?.Invoke(controls);
+    }
+}

--- a/src/PEAKLib.UI/Hooks/PauseMenuMainPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuMainPageHooks.cs
@@ -18,7 +18,12 @@ static class PauseMenuMainPageHooks
 
     private static void PostfixEnable(PauseMenuMainPage self)
     {
+        MenuAPI.pauseMenuBuilderDelegate?.Invoke(self.transform);
+
         var controls = self.transform.parent.Find("ControlsPage");
         MenuAPI.controlsMenuBuilderDelegate?.Invoke(controls);
+
+        var settings = self.transform.parent.Find("SettingsPage"); 
+        MenuAPI.settingsMenuBuilderDelegate?.Invoke(settings.gameObject.transform);
     }
 }

--- a/src/PEAKLib.UI/Hooks/PauseMenuMainPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuMainPageHooks.cs
@@ -23,7 +23,9 @@ static class PauseMenuMainPageHooks
         var controls = self.transform.parent.Find("ControlsPage");
         MenuAPI.controlsMenuBuilderDelegate?.Invoke(controls);
 
-        var settings = self.transform.parent.Find("SettingsPage"); 
-        MenuAPI.settingsMenuBuilderDelegate?.Invoke(settings.gameObject.transform);
+        // uncomment when we can get rid of PauseMenuSettingsMenuPageHooks
+        // below is a breaking change for some dependent mods due to inproper usage of the settingsmenubuilderdelegate
+        //var settings = self.transform.parent.Find("SettingsPage"); 
+        //MenuAPI.settingsMenuBuilderDelegate?.Invoke(settings.gameObject.transform);
     }
 }

--- a/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
@@ -15,6 +15,7 @@ static class PauseMenuSettingsMenuPageHooks
 
     static void Prefix_Start(PauseMenuSettingsMenuPage self)
     {
-        //moved
+        //need this here for now to not make breaking changes to other mods (ie. PocketPassport)
+        MenuAPI.settingsMenuBuilderDelegate?.Invoke(self.gameObject.transform);
     }
 }

--- a/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
@@ -15,7 +15,6 @@ static class PauseMenuSettingsMenuPageHooks
 
     static void Prefix_Start(PauseMenuSettingsMenuPage self)
     {
-        MenuAPI.pauseMenuBuilderDelegate?.Invoke(self.backButton.transform);
-        MenuAPI.settingsMenuBuilderDelegate?.Invoke(self.gameObject.transform);
+        //moved
     }
 }

--- a/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
@@ -17,5 +17,8 @@ static class PauseMenuSettingsMenuPageHooks
     {
         MenuAPI.pauseMenuBuilderDelegate?.Invoke(self.backButton.transform);
         MenuAPI.settingsMenuBuilderDelegate?.Invoke(self.gameObject.transform);
+
+        var controls = self.transform.parent.Find("ControlsPage");
+        MenuAPI.controlsMenuBuilderDelegate?.Invoke(controls);
     }
 }

--- a/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
+++ b/src/PEAKLib.UI/Hooks/PauseMenuSettingsMenuPageHooks.cs
@@ -17,8 +17,5 @@ static class PauseMenuSettingsMenuPageHooks
     {
         MenuAPI.pauseMenuBuilderDelegate?.Invoke(self.backButton.transform);
         MenuAPI.settingsMenuBuilderDelegate?.Invoke(self.gameObject.transform);
-
-        var controls = self.transform.parent.Find("ControlsPage");
-        MenuAPI.controlsMenuBuilderDelegate?.Invoke(controls);
     }
 }

--- a/src/PEAKLib.UI/MenuAPI.cs
+++ b/src/PEAKLib.UI/MenuAPI.cs
@@ -16,7 +16,8 @@ public static class MenuAPI
 {
     internal static BuilderDelegate? pauseMenuBuilderDelegate,
         mainMenuBuilderDelegate,
-        settingsMenuBuilderDelegate;
+        settingsMenuBuilderDelegate,
+        controlsMenuBuilderDelegate;
 
     /// <summary>
     /// Delegate to create elements
@@ -44,6 +45,13 @@ public static class MenuAPI
     /// <param name="builderDelegate"></param>
     public static void AddToSettingsMenu(BuilderDelegate builderDelegate) =>
         settingsMenuBuilderDelegate += builderDelegate;
+
+    /// <summary>
+    /// Add element(s) to Controls Menu
+    /// </summary>
+    /// <param name="builderDelegate"></param>
+    public static void AddToControlsMenu(BuilderDelegate builderDelegate) =>
+        controlsMenuBuilderDelegate += builderDelegate;
 
     /// <summary>
     /// Creates a page to store your elements

--- a/src/PEAKLib.UI/MenuAPI.cs
+++ b/src/PEAKLib.UI/MenuAPI.cs
@@ -1,5 +1,6 @@
 ﻿using PEAKLib.Core;
 using PEAKLib.UI.Elements;
+using PEAKLib.UI.Elements.Settings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -216,5 +217,65 @@ public static class MenuAPI
 
 
         return new TranslationKey(index);
+    }
+
+    /// <summary>
+    /// Creates an on/off setting that can be added to any of the vanilla setting tabs
+    /// <param name="displayName">The display name of the setting. You will want to use <see cref="CreateLocalization(string)"/> for your displayName. Without the localization, the text will appear as LOC: displayName </param>
+    /// <param name="defaultValue">Default value of the setting</param>
+    /// <param name="category">determines which tab to display the setting</param>
+    /// <param name="currentValue">Current value of the setting</param>
+    /// <param name="saveCallback">Action called when the value is updated</param>
+    /// </summary>
+    public static GenericBoolSetting AddOnOffSetting(string displayName, bool defaultValue, SettingsCategory category, bool currentValue, Action<bool>? saveCallback = null)
+    {
+        GenericBoolSetting setting = new(displayName, defaultValue, category, currentValue, saveCallback);
+        
+        if (SettingsHandler.Instance == null)
+            UIPlugin.Log.LogWarning($"SettingsHandler.Instance is null! You will need to manually add this setting ({displayName})");
+        else
+            SettingsHandler.Instance.AddSetting(setting);
+
+        return setting;
+    }
+
+    /// <summary>
+    /// Creates a slider setting that can be added to any of the vanilla setting tabs
+    /// <param name="displayName">The display name of the setting. You will want to use <see cref="CreateLocalization(string)"/> for your displayName. Without the localization, the text will appear as LOC: displayName </param>
+    /// <param name="defaultValue">Default value of the setting</param>
+    /// <param name="category">determines which tab to display the setting</param>
+    /// <param name="currentValue">Current value of the setting</param>
+    /// <param name="minValue">Minimum value of the setting</param>
+    /// <param name="maxValue">Maximum value of the setting</param>
+    /// <param name="saveCallback">Action called when the value is updated</param>
+    /// </summary>
+    public static GenericFloatSetting AddSliderSetting(string displayName, float defaultValue, SettingsCategory category, float currentValue, float minValue = 0f, float maxValue = 1000f, Action<float>? saveCallback = null)
+    {
+        GenericFloatSetting setting = new(displayName, defaultValue, category, minValue, maxValue, currentValue, saveCallback);
+        if (SettingsHandler.Instance == null)
+            UIPlugin.Log.LogWarning($"SettingsHandler.Instance is null! You will need to manually add this setting ({displayName})");
+        else
+            SettingsHandler.Instance.AddSetting(setting);
+
+        return setting;
+    }
+
+    /// <summary>
+    /// Creates a slider setting that can be added to any of the vanilla setting tabs
+    /// <param name="displayName">The display name of the setting. You will want to use <see cref="CreateLocalization(string)"/> for your displayName. Without the localization, the text will appear as LOC: displayName </param>
+    /// <param name="defaultValue">Default value of the setting</param>
+    /// <param name="category">determines which tab to display the setting</param>
+    /// <param name="currentValue">Current value of the setting</param>
+    /// <param name="saveCallback">Action called when the value is updated</param>
+    /// </summary>
+    public static GenericEnumSetting<T> AddEnumSetting<T>(string displayName, T currentValue, T defaultValue, SettingsCategory category, Action<T>? saveCallback = null) where T : unmanaged, Enum
+    {
+        GenericEnumSetting<T> setting = new(displayName, currentValue, defaultValue, category, saveCallback);
+        if (SettingsHandler.Instance == null)
+            UIPlugin.Log.LogWarning($"SettingsHandler.Instance is null! You will need to manually add this setting ({displayName})");
+        else
+            SettingsHandler.Instance.AddSetting(setting);
+
+        return setting;
     }
 }


### PR DESCRIPTION
To-Do:
- Version bump
- Official changelog noting all changes
- Testing & Design Review

PEAKLib.UI Updates in this PR:
- Added new templates relating to the recently added Controls Menu
- Added hook for PauseMenuControlsPage to grab new templates (these references cannot be grabbed any earlier as far as I'm aware)
- Added hook for PauseMenuMainPage
    - Fixed pauseMenuBuilderDelegate not invoking until the settings page was opened by moving it to here. Will now invoke on pause press.
    - controlsMenuBuilderDelegate is invoked and settingsMenuBuilderDelegate could be invoked here in the future (currently would cause breaking changes for mods that are using this delegate to add buttons to the pause main menu)
- New in MenuAPI:
    - AddToControlsMenu (Add element(s) to Controls Menu) using controlsMenuBuilderDelegate 
    - AddOnOffSetting (Add an on/off setting to any vanilla setting tab)
    - AddSliderSetting (Add slider setting to any vanilla setting tab)
    - AddEnumSetting (Add drop-down setting to any vanilla setting tab using an enum)
- Added GenericBoolSetting, GenericFloatSetting, and GenericEnumSetting classes to support the last 3 additions to MenuAPI.
- Updated PeakHorizontalTab class with some additional stuff to support modifying the tabs at runtime. Also added the option to assign a custom background color before tab creation.

ModConfig Updates in this PR:
- Visual overhaul of Mod Settings page & Buttons
- Added Modded Controls page & buttons in Controls Menu and Modded Settings page
- Modded Controls page has a button to Modded Settings page as well
- Modded Controls page automatically generates a listing from KeyCode type configuration items AND string type configuration items with a default value matching an expected input path binding string.
- Modded Controls page is equipped with interactive key-rebinding pages and re-uses the reset element from the vanilla controls page.
- Key name values in the Modded Controls page are translated to key control sprites in a best effort basis. A method has been created to translate KeyCode names to input binding paths. 
- Duplicate Key bindings will show with a warning symbol to inform the player they have multiple modded controls bound to the same key. Both types of keybinds (keycode and binding path string) work together with this feature as their string results are compared.
- The configuration items on the Modded Controls page will still exist in the Mod Settings page to avoid confusing players.
- Added secondary PeakHorizontalTab element to Mod Settings page for config sections (also added relevant code for tracking this information)
- Added some common use generic methods to SettingsHandlerUtility.cs
- Updated Bepinex SettingOptions to use ConfigEntryBase for better tracking of value changes.
    - Fixes an issue where changing a configuration item outside the Mod Settings page would not update the value in the Mod Settings page
    - The ConfigEntryBase value is required as part of the IBepInExProperty interface, as well as a new RefreshValueFromConfig method.
    - This also allowed for the functionality behind displaying only config items with a specific section name
- Added support for ``Double`` type config items
- Added AcceptableValueList detection for ``string`` type config items to create an enum drop-down box setting type

