### PR TITLE
ModConfig fix for AutoReload support (duplicate entries)

### DIFF
--- a/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
@@ -421,7 +421,13 @@ internal class ModSettingsMenu : MonoBehaviour
         {
             // remove settings with dead (null) plugin instances, fixes autoreload plugins with duplicate settings issue
             var deadSettings = GameHandler.Instance.SettingsHandler.GetSettingsThatImplements<IBepInExProperty>().FindAll(x => x.Pluginfo.Instance == null).Cast<Setting>();
-            GameHandler.Instance.SettingsHandler.settings.RemoveAll(x => deadSettings.Contains(x));
+            if (deadSettings.Any())
+            {
+                GameHandler.Instance.SettingsHandler.settings.RemoveAll(x => deadSettings.Contains(x));
+                // get fresh config items
+                ModConfigPlugin.ProcessModEntries();
+            }
+            
 
             settings = GameHandler.Instance.SettingsHandler.GetSettingsThatImplements<IBepInExProperty>();
         }

--- a/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
+++ b/src/PEAKLib.ModConfig/Components/ModSettingsMenu.cs
@@ -16,8 +16,6 @@ internal class ModSettingsMenu : MonoBehaviour
 {
     private void OnEnable()
     {
-        RefreshSettings();
-
         if (ModTabs != null && ModTabs.selectedButton != null)
             ModTabs.Select(ModTabs.selectedButton);
     }
@@ -421,9 +419,11 @@ internal class ModSettingsMenu : MonoBehaviour
     {
         if (GameHandler.Instance != null)
         {
-            var exposedsettings =
-                GameHandler.Instance.SettingsHandler.GetSettingsThatImplements<IBepInExProperty>();
-            settings = [.. exposedsettings.Where(setting => setting.ConfigBase != null)]; // fix for autoreload mods?
+            // remove settings with dead (null) plugin instances, fixes autoreload plugins with duplicate settings issue
+            var deadSettings = GameHandler.Instance.SettingsHandler.GetSettingsThatImplements<IBepInExProperty>().FindAll(x => x.Pluginfo.Instance == null).Cast<Setting>();
+            GameHandler.Instance.SettingsHandler.settings.RemoveAll(x => deadSettings.Contains(x));
+
+            settings = GameHandler.Instance.SettingsHandler.GetSettingsThatImplements<IBepInExProperty>();
         }
     }
 

--- a/src/PEAKLib.ModConfig/IBepInExProperty.cs
+++ b/src/PEAKLib.ModConfig/IBepInExProperty.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx.Configuration;
+﻿using BepInEx;
+using BepInEx.Configuration;
 
 namespace PEAKLib.ModConfig;
 
@@ -6,6 +7,7 @@ internal interface IBepInExProperty
 {
     //so we can refresh values from config and add functional section tabs
     internal ConfigEntryBase ConfigBase { get; }
+    internal PluginInfo Pluginfo { get; }
 
     internal void RefreshValueFromConfig();
     internal void SetDefaultValue();

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -203,8 +203,9 @@ public partial class ModConfigPlugin : BaseUnityPlugin
             settingsMenu.ModTabs = moddedSettingsTABS;
             settingsMenu.SectionTabs = modSectionTABS;
 
-            foreach (var (modName, configEntryBases) in GetModConfigEntries())
+            foreach (var mod in ModSectionNames.SectionNames)
             {
+                var modName = mod.ModName;
                 var tabButton = horizontalTabs.AddTab(modName);
                 var moddedButton = tabButton.AddComponent<ModdedTABSButton>();
                 moddedButton.category = modName;
@@ -339,8 +340,9 @@ public partial class ModConfigPlugin : BaseUnityPlugin
     //Called during mod initialization AND whenever the mod settings page is opened
     private static void ProcessModEntries()
     {
-        foreach (var (modName, configEntryBases) in GetModConfigEntries())
+        foreach (var (plugin, configEntryBases) in GetModConfigEntries())
         {
+            var modName = FixNaming(plugin.Metadata.Name);
             ModSectionNames sectionTracker = ModSectionNames.SetMod(modName);
 
             foreach (var configEntry in configEntryBases)
@@ -358,6 +360,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     if (configEntry.SettingType == typeof(bool))
                         SettingsHandlerUtility.AddBoolToTab(
                             configEntry,
+                            plugin,
                             modName,
                             newVal => configEntry.BoxedValue = newVal
                         );
@@ -365,6 +368,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     {
                         SettingsHandlerUtility.AddFloatToTab(
                             configEntry,
+                            plugin,
                             modName,
                             newVal => configEntry.BoxedValue = newVal
                         );
@@ -373,6 +377,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     {
                         SettingsHandlerUtility.AddDoubleToTab(
                             configEntry,
+                            plugin,
                             modName,
                             newVal => configEntry.BoxedValue = newVal
                         );
@@ -381,6 +386,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     {
                         SettingsHandlerUtility.AddIntToTab(
                             configEntry,
+                            plugin,
                             modName,
                             newVal => configEntry.BoxedValue = newVal
                         );
@@ -395,6 +401,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         {
                             SettingsHandlerUtility.AddKeyPathToTab(
                                 configEntry,
+                                plugin,
                                 modName,
                                 newVal => configEntry.BoxedValue = newVal
                             );
@@ -409,6 +416,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         {
                             SettingsHandlerUtility.AddEnumToTab(
                                 configEntry,
+                                plugin,
                                 modName,
                                 false,
                                 newVal =>
@@ -421,6 +429,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                         {
                             SettingsHandlerUtility.AddStringToTab(
                                 configEntry,
+                                plugin,
                                 modName,
                                 newVal => configEntry.BoxedValue = newVal
                             );
@@ -430,6 +439,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     {
                         SettingsHandlerUtility.AddKeybindToTab(
                             configEntry,
+                            plugin,
                             modName,
                             newVal => configEntry.BoxedValue = newVal
                         );
@@ -438,6 +448,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
                     {
                         SettingsHandlerUtility.AddEnumToTab(
                             configEntry,
+                            plugin,
                             modName,
                             true,
                             newVal =>
@@ -461,9 +472,10 @@ public partial class ModConfigPlugin : BaseUnityPlugin
     }
 
     // From https://github.com/IsThatTheRealNick/REPOConfig/blob/main/REPOConfig/ConfigMenu.cs#L453
-    private static Dictionary<string, ConfigEntryBase[]> GetModConfigEntries()
+    // modified to capture plugin instances directly instead of just mod names
+    private static Dictionary<PluginInfo, ConfigEntryBase[]> GetModConfigEntries()
     {
-        var configs = new Dictionary<string, ConfigEntryBase[]>();
+        var configs = new Dictionary<PluginInfo, ConfigEntryBase[]>();
 
         foreach (var plugin in Chainloader.PluginInfos.Values.OrderBy(p => p.Metadata.Name))
         {
@@ -484,7 +496,7 @@ public partial class ModConfigPlugin : BaseUnityPlugin
             }
 
             if (configEntries.Count > 0)
-                configs.TryAdd(FixNaming(plugin.Metadata.Name), [.. configEntries]);
+                configs.TryAdd(plugin, [.. configEntries]);
         }
 
         return configs;

--- a/src/PEAKLib.ModConfig/Plugin.cs
+++ b/src/PEAKLib.ModConfig/Plugin.cs
@@ -337,8 +337,8 @@ public partial class ModConfigPlugin : BaseUnityPlugin
     }
 
     //Processes Bepinex config items to Settings entries
-    //Called during mod initialization AND whenever the mod settings page is opened
-    private static void ProcessModEntries()
+    //Called during 1) mod initialization 2) mod settings page is opened 3) null plugin instances are found
+    internal static void ProcessModEntries()
     {
         foreach (var (plugin, configEntryBases) in GetModConfigEntries())
         {

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExDouble.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExDouble.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BepInEx;
 using BepInEx.Configuration;
 using Unity.Mathematics;
 using Zorro.Settings;
@@ -8,6 +9,7 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExDouble(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string categoryName = "Mods",
     Action<double>? saveCallback = null,
     Action<BepInExDouble>? onApply = null
@@ -17,6 +19,8 @@ internal class BepInExDouble(
     {
         get => entryBase;
     }
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
 
     public override void Load(ISettingsSaveLoad loader)
     {

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExEnum.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExEnum.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using UnityEngine;
@@ -13,6 +14,7 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExEnum(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category = "Mods",
     bool isEnum = true,
     Action<string>? saveCallback = null,
@@ -23,6 +25,8 @@ internal class BepInExEnum(
     {
         get => entryBase;
     }
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
 
     private static GameObject? _settingUICell = null;
     public static GameObject? SettingUICell

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExFloat.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExFloat.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using Unity.Mathematics;
@@ -12,15 +13,15 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExFloat(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string categoryName = "Mods",
     Action<float>? saveCallback = null,
     Action<BepInExFloat>? onApply = null
 ) : FloatSetting, IBepInExProperty, IExposedSetting
 {
-    ConfigEntryBase IBepInExProperty.ConfigBase
-    {
-        get => entryBase;
-    }
+    ConfigEntryBase IBepInExProperty.ConfigBase => entryBase;
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
 
     private static GameObject? _settingUICell = null;
     public static GameObject? SettingUICell

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExInputBindingSetting.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExInputBindingSetting.cs
@@ -1,4 +1,5 @@
 using System;
+using BepInEx;
 using BepInEx.Configuration;
 using Zorro.Settings;
 using static PEAKLib.ModConfig.SettingsHandlerUtility;
@@ -7,11 +8,14 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal abstract class BepInExInputBindingSetting<TValue>(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category,
     Action<TValue>? saveCallback
 ) : Setting, IBepInExProperty, IExposedSetting
 {
     public ConfigEntryBase ConfigBase => entryBase;
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
 
     public TValue Value { get; private set; } = GetCurrentValue<TValue>(entryBase);
 

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExInt.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExInt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using TMPro;
@@ -13,15 +14,16 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExInt(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category = "Mods",
     Action<int>? saveCallback = null,
     Action<BepInExInt>? onApply = null
 ) : IntSetting, IBepInExProperty, IExposedSetting
 {
-    ConfigEntryBase IBepInExProperty.ConfigBase
-    {
-        get => entryBase;
-    }
+    ConfigEntryBase IBepInExProperty.ConfigBase => entryBase;
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
+
     private static GameObject? _settingUICell = null;
     public static GameObject? SettingUICell
     {

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyCode.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyCode.cs
@@ -1,4 +1,5 @@
 using System;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using UnityEngine;
@@ -7,10 +8,11 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExKeyCode(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category = "Mods",
     Action<KeyCode>? saveCallback = null,
     Action<BepInExKeyCode>? onApply = null
-) : BepInExInputBindingSetting<KeyCode>(entryBase, category, saveCallback)
+) : BepInExInputBindingSetting<KeyCode>(entryBase, plugin, category, saveCallback)
 {
     private static GameObject? _settingUICell;
     public static GameObject? SettingUICell

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyPath.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExKeyPath.cs
@@ -1,4 +1,5 @@
 using System;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using UnityEngine;
@@ -7,10 +8,11 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExKeyPath(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category = "Mods",
     Action<string>? saveCallback = null,
     Action<BepInExKeyPath>? onApply = null
-) : BepInExInputBindingSetting<string>(entryBase, category, saveCallback)
+) : BepInExInputBindingSetting<string>(entryBase, plugin, category, saveCallback)
 {
     private static GameObject? _settingUICell;
     public static GameObject? SettingUICell

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExOffOn.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExOffOn.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions.SettingUI;
 using UnityEngine;
@@ -13,15 +14,15 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExOffOn(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category = "Mods",
     Action<bool>? saveCallback = null,
     Action<BepInExOffOn>? onApply = null
 ) : OffOnSetting, IBepInExProperty, IExposedSetting
 {
-    ConfigEntryBase IBepInExProperty.ConfigBase
-    {
-        get => entryBase;
-    }
+    ConfigEntryBase IBepInExProperty.ConfigBase => entryBase;
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
 
     private static GameObject? _settingUICell = null;
     public static GameObject? SettingUICell

--- a/src/PEAKLib.ModConfig/SettingOptions/BepInExString.cs
+++ b/src/PEAKLib.ModConfig/SettingOptions/BepInExString.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.UI;
 using PEAKLib.UI.Elements;
@@ -14,6 +15,7 @@ namespace PEAKLib.ModConfig.SettingOptions;
 
 internal class BepInExString(
     ConfigEntryBase entryBase,
+    PluginInfo plugin,
     string category = "Mods",
     Action<string>? saveCallback = null,
     Action<BepInExString>? onApply = null
@@ -23,6 +25,8 @@ internal class BepInExString(
     {
         get => entryBase;
     }
+
+    PluginInfo IBepInExProperty.Pluginfo => plugin;
 
     public string PlaceholderText { get; set; } = GetDefaultValue<string>(entryBase) ?? "";
     private static GameObject? _settingUICell = null;

--- a/src/PEAKLib.ModConfig/SettingsHandlerUtility.cs
+++ b/src/PEAKLib.ModConfig/SettingsHandlerUtility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using BepInEx;
 using BepInEx.Configuration;
 using PEAKLib.ModConfig.SettingOptions;
 using UnityEngine;
@@ -10,6 +11,7 @@ internal static class SettingsHandlerUtility
 {
     internal static void AddBoolToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<bool>? saveCallback = null
     )
@@ -19,11 +21,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExOffOn(entry, tabName, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExOffOn(entry, plugin, tabName, saveCallback));
     }
 
     internal static void AddFloatToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<float>? applyCallback = null
     )
@@ -33,11 +36,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExFloat(entry, tabName, applyCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExFloat(entry, plugin, tabName, applyCallback));
     }
 
     internal static void AddDoubleToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<double>? applyCallback = null
     )
@@ -47,11 +51,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExDouble(entry, tabName, applyCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExDouble(entry, plugin, tabName, applyCallback));
     }
 
     internal static void AddIntToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<int>? saveCallback = null
     )
@@ -61,11 +66,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExInt(entry, tabName, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExInt(entry, plugin, tabName, saveCallback));
     }
 
     internal static void AddStringToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<string>? saveCallback = null
     )
@@ -75,11 +81,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExString(entry, tabName, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExString(entry, plugin, tabName, saveCallback));
     }
 
     internal static void AddKeyPathToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<string>? saveCallback = null
     )
@@ -89,11 +96,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExKeyPath(entry, tabName, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExKeyPath(entry, plugin, tabName, saveCallback));
     }
 
     internal static void AddKeybindToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         Action<KeyCode>? saveCallback
     )
@@ -103,11 +111,12 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExKeyCode(entry, tabName, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExKeyCode(entry, plugin, tabName, saveCallback));
     }
 
     internal static void AddEnumToTab(
         ConfigEntryBase entry,
+        PluginInfo plugin,
         string tabName,
         bool isEnum,
         Action<string>? saveCallback
@@ -118,7 +127,7 @@ internal static class SettingsHandlerUtility
                 "You're registering options too early! Use the Start() function to create new options!"
             );
 
-        SettingsHandler.Instance.AddSetting(new BepInExEnum(entry, tabName, isEnum, saveCallback));
+        SettingsHandler.Instance.AddSetting(new BepInExEnum(entry, plugin, tabName, isEnum, saveCallback));
     }
 
     public static T GetDefaultValue<T>(ConfigEntry<T> entry)


### PR DESCRIPTION
Fix for #57

When processing config entries we now cache the entire plugininfo of the config item rather than just the mod name. The plugininfo is later used to check for null plugin instances in the list of already created settings. Any setting with a null plugin instance is then removed.